### PR TITLE
[#72] GitHub Oauth API 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -208,6 +208,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1858,6 +1863,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1954,6 +1964,40 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1982,6 +2026,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -2496,6 +2545,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "umzug": {
       "version": "2.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,8 @@
     "morgan": "~1.9.1",
     "mysql2": "^2.2.5",
     "nodemon": "^2.0.6",
+    "passport": "^0.4.1",
+    "passport-github2": "^0.1.12",
     "sequelize": "^6.3.5"
   },
   "devDependencies": {

--- a/backend/src/db/migrations/20201102160147-add-associations-oneToMany.js
+++ b/backend/src/db/migrations/20201102160147-add-associations-oneToMany.js
@@ -4,7 +4,7 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.addColumn(
       'Issues',
-      'author',
+      'authorId',
       {
         type: Sequelize.INTEGER,
         references: {

--- a/backend/src/db/models/user.js
+++ b/backend/src/db/models/user.js
@@ -7,7 +7,7 @@ module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     static associate(models) {
       User.hasMany(models.Issue, {
-        foreignKey: 'author',
+        foreignKey: 'authorId',
       });
       User.hasMany(models.Comment);
       User.belongsToMany(models.Issue, {

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,12 +1,18 @@
 const express = require('express');
+const passport = require('passport');
 const router = express.Router();
+require('../services/passportServices');
 
-router.post('/siginIn', (req, res) => {
+router.post('/signIn', (req, res) => {
   res.json();
 });
 
-router.post('/siginUp', (req, res) => {
+router.post('/signUp', (req, res) => {
   res.json();
 });
+
+router.get('/github/callback', passport.authenticate('github', { failureRedirect: '/login', session: false }), (req, res) => res.redirect('/'));
+
+router.get('/github', passport.authenticate('github', { session: false }));
 
 module.exports = router;

--- a/backend/src/services/passportServices.js
+++ b/backend/src/services/passportServices.js
@@ -1,0 +1,19 @@
+const passport = require('passport');
+const GitHubStrategy = require('passport-github2').Strategy;
+const { User } = require('../db/models');
+
+passport.use(new GitHubStrategy({
+  clientID: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  callbackURL: 'http://localhost:3000/api/auth/github/callback',
+  session: false,
+},
+async (accessToken, refreshToken, profile, callback) => {
+  console.log(profile);
+  const user = await User.findOrCreate({
+    where: { userName: profile.username },
+    defaults: { password: null, profile: profile._json.avatar_url, authType: 'github', isDeleted: false },
+  });
+  return callback(null, user);
+},
+));


### PR DESCRIPTION
## 구현의도
- GitHub OAuth를 통한 회원가입/로그인 작업을 하는 API 입니다. 

## 흐름도, 다이어그램
- 작업흐름
  - routes/auth-> services/passportServices -> db/models/user -> DB 서버

## 사용된 기술
- passport
- passport-github2

## 리뷰요청 & 논의사항 & 궁금한점
- PUT, DELETE 문의 구현 방식과 DB에서 변경이 잘 이루어졌는지 확인하는 방법을 비교하고 논의해보고 싶습니다. 

closes #72