### PR TITLE
Filter화면 및 UserList화면 구현 

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -27,11 +27,14 @@
 		51445AAA254A95D700875BA5 /* InsetLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51445AA9254A95D600875BA5 /* InsetLabel.swift */; };
 		51445AAF254AA11B00875BA5 /* MilestoneBadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51445AAE254AA11A00875BA5 /* MilestoneBadgeLabel.swift */; };
 		51445AB4254AA13000875BA5 /* LabelBadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51445AB3254AA13000875BA5 /* LabelBadgeLabel.swift */; };
+		51DE98F62551898100A2E2C8 /* FilterWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE98F52551898100A2E2C8 /* FilterWorker.swift */; };
+		51DE98FE25518DF000A2E2C8 /* UserListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE98FD25518DEF00A2E2C8 /* UserListViewController.swift */; };
+		51DE99032551940700A2E2C8 /* UserListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE99022551940700A2E2C8 /* UserListInteractor.swift */; };
 		51FBF8EC255047F000F38CCC /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FBF8EB255047F000F38CCC /* FloatingButton.swift */; };
 		826F6307255154E80005D669 /* FilterIssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826F6306255154E80005D669 /* FilterIssueViewController.swift */; };
 		826F630C25515ADA0005D669 /* FilterIssueInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826F630B25515ADA0005D669 /* FilterIssueInteractor.swift */; };
 		82CF7CB2254A8B3E0061121C /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CF7CB1254A8B3E0061121C /* Label.swift */; };
-		82CF7CB7254A8B500061121C /* Assignee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CF7CB6254A8B500061121C /* Assignee.swift */; };
+		82CF7CB7254A8B500061121C /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CF7CB6254A8B500061121C /* User.swift */; };
 		82CF7CC8254AA4FD0061121C /* IssueWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CF7CC7254AA4FD0061121C /* IssueWorker.swift */; };
 		ACFD28902EF2C9069AABC467 /* Pods_IssueTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85C40AA660A2BF0DB0BFF45D /* Pods_IssueTrackerTests.framework */; };
 		FB34BCA23808D41DE61545BE /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDFBEEF6F47ED00855F21BFF /* Pods_IssueTracker.framework */; };
@@ -81,11 +84,14 @@
 		51445AA9254A95D600875BA5 /* InsetLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetLabel.swift; sourceTree = "<group>"; };
 		51445AAE254AA11A00875BA5 /* MilestoneBadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneBadgeLabel.swift; sourceTree = "<group>"; };
 		51445AB3254AA13000875BA5 /* LabelBadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelBadgeLabel.swift; sourceTree = "<group>"; };
+		51DE98F52551898100A2E2C8 /* FilterWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterWorker.swift; sourceTree = "<group>"; };
+		51DE98FD25518DEF00A2E2C8 /* UserListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListViewController.swift; sourceTree = "<group>"; };
+		51DE99022551940700A2E2C8 /* UserListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListInteractor.swift; sourceTree = "<group>"; };
 		51FBF8EB255047F000F38CCC /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
 		826F6306255154E80005D669 /* FilterIssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterIssueViewController.swift; sourceTree = "<group>"; };
 		826F630B25515ADA0005D669 /* FilterIssueInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterIssueInteractor.swift; sourceTree = "<group>"; };
 		82CF7CB1254A8B3E0061121C /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
-		82CF7CB6254A8B500061121C /* Assignee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignee.swift; sourceTree = "<group>"; };
+		82CF7CB6254A8B500061121C /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		82CF7CC7254AA4FD0061121C /* IssueWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueWorker.swift; sourceTree = "<group>"; };
 		85C40AA660A2BF0DB0BFF45D /* Pods_IssueTrackerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTrackerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB5F9DE528E49AF31543BA82 /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
@@ -247,7 +253,7 @@
 				51326F13254971FF00C0C273 /* Issue.swift */,
 				51326F1B2549723000C0C273 /* IssueDataSource.swift */,
 				82CF7CB1254A8B3E0061121C /* Label.swift */,
-				82CF7CB6254A8B500061121C /* Assignee.swift */,
+				82CF7CB6254A8B500061121C /* User.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -269,6 +275,9 @@
 			children = (
 				826F6306255154E80005D669 /* FilterIssueViewController.swift */,
 				826F630B25515ADA0005D669 /* FilterIssueInteractor.swift */,
+				51DE98F52551898100A2E2C8 /* FilterWorker.swift */,
+				51DE98FD25518DEF00A2E2C8 /* UserListViewController.swift */,
+				51DE99022551940700A2E2C8 /* UserListInteractor.swift */,
 			);
 			path = FilterIssue;
 			sourceTree = "<group>";
@@ -507,15 +516,18 @@
 				51326F0E2549594F00C0C273 /* IssueCollectionViewCell.swift in Sources */,
 				51445AB4254AA13000875BA5 /* LabelBadgeLabel.swift in Sources */,
 				51326EE32549407C00C0C273 /* IssueListViewController.swift in Sources */,
+				51DE98F62551898100A2E2C8 /* FilterWorker.swift in Sources */,
 				82CF7CB2254A8B3E0061121C /* Label.swift in Sources */,
 				51326EEB2549408A00C0C273 /* LabelListViewController.swift in Sources */,
 				51326E8025492F3A00C0C273 /* AppDelegate.swift in Sources */,
-				82CF7CB7254A8B500061121C /* Assignee.swift in Sources */,
+				82CF7CB7254A8B500061121C /* User.swift in Sources */,
 				51445AAF254AA11B00875BA5 /* MilestoneBadgeLabel.swift in Sources */,
 				826F6307255154E80005D669 /* FilterIssueViewController.swift in Sources */,
 				51326E8225492F3A00C0C273 /* SceneDelegate.swift in Sources */,
 				51326F0925494E0500C0C273 /* IssueListInteractor.swift in Sources */,
+				51DE98FE25518DF000A2E2C8 /* UserListViewController.swift in Sources */,
 				51326F1C2549723000C0C273 /* IssueDataSource.swift in Sources */,
+				51DE99032551940700A2E2C8 /* UserListInteractor.swift in Sources */,
 				51FBF8EC255047F000F38CCC /* FloatingButton.swift in Sources */,
 				82CF7CC8254AA4FD0061121C /* IssueWorker.swift in Sources */,
 				51326EF5254940A000C0C273 /* SettingViewController.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -371,7 +371,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="JMT-94-Ir7" kind="show" id="mTX-Lq-j4E"/>
+                                            <segue destination="JMT-94-Ir7" kind="show" identifier="showAuthorList" id="mTX-Lq-j4E"/>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="ooa-Ye-CgH" style="IBUITableViewCellStyleDefault" id="Sll-X6-1xe">
@@ -424,6 +424,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="JMT-94-Ir7" kind="show" identifier="showAssigneeList" id="w34-j2-yz5"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -450,7 +453,7 @@
             </objects>
             <point key="canvasLocation" x="1916" y="836"/>
         </scene>
-        <!--작성자-->
+        <!--USERS-->
         <scene sceneID="iYY-VC-qZc">
             <objects>
                 <viewController id="JMT-94-Ir7" customClass="UserListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
@@ -488,14 +491,14 @@
                             <constraint firstItem="wHd-SH-Mwu" firstAttribute="bottom" secondItem="Shd-Zg-pmx" secondAttribute="bottom" id="uCT-u0-G1O"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="작성자" id="5ZR-MT-v0M"/>
+                    <navigationItem key="navigationItem" title="USERS" id="5ZR-MT-v0M"/>
                     <connections>
                         <outlet property="userCollectionView" destination="Shd-Zg-pmx" id="TZ9-h4-eja"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qw2-ax-zOV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2678" y="836"/>
+            <point key="canvasLocation" x="2687" y="836"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="RRA-zr-ZA1">
@@ -516,6 +519,9 @@
             <point key="canvasLocation" x="1226" y="836"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="w34-j2-yz5"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="secondaryLabelColor">

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="k72-CT-Zpz">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -253,7 +253,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aXL-uo-kzR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3872.4637681159425" y="835.71428571428567"/>
+            <point key="canvasLocation" x="4442" y="836"/>
         </scene>
         <!--필터 선택-->
         <scene sceneID="ByT-cH-jvS">
@@ -370,6 +370,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="JMT-94-Ir7" kind="show" id="mTX-Lq-j4E"/>
+                                        </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="ooa-Ye-CgH" style="IBUITableViewCellStyleDefault" id="Sll-X6-1xe">
                                         <rect key="frame" x="20" y="372.5" width="374" height="43.5"/>
@@ -445,7 +448,54 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="QwP-qq-EIB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2139.130434782609" y="785.49107142857144"/>
+            <point key="canvasLocation" x="1916" y="836"/>
+        </scene>
+        <!--작성자-->
+        <scene sceneID="iYY-VC-qZc">
+            <objects>
+                <viewController id="JMT-94-Ir7" customClass="UserListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BCA-i6-hPu">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Shd-Zg-pmx">
+                                <rect key="frame" x="0.0" y="108" width="414" height="700"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gi6-Pv-9Ra">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="4fN-8y-6tN">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="cDF-mW-ken">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="wHd-SH-Mwu"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Shd-Zg-pmx" firstAttribute="top" secondItem="wHd-SH-Mwu" secondAttribute="top" id="273-gH-cO4"/>
+                            <constraint firstItem="Shd-Zg-pmx" firstAttribute="leading" secondItem="wHd-SH-Mwu" secondAttribute="leading" id="IKo-3d-2aG"/>
+                            <constraint firstItem="wHd-SH-Mwu" firstAttribute="trailing" secondItem="Shd-Zg-pmx" secondAttribute="trailing" id="Og4-rO-nJu"/>
+                            <constraint firstItem="wHd-SH-Mwu" firstAttribute="bottom" secondItem="Shd-Zg-pmx" secondAttribute="bottom" id="uCT-u0-G1O"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="작성자" id="5ZR-MT-v0M"/>
+                    <connections>
+                        <outlet property="userCollectionView" destination="Shd-Zg-pmx" id="TZ9-h4-eja"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Qw2-ax-zOV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2678" y="836"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="RRA-zr-ZA1">

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -390,6 +390,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="qgV-Aj-uCz" kind="show" id="WxA-Ry-SEX"/>
+                                        </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="a96-CS-p9t" style="IBUITableViewCellStyleDefault" id="95K-bu-5pS">
                                         <rect key="frame" x="20" y="416" width="374" height="43.5"/>
@@ -407,6 +410,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="jP9-w6-KkU" kind="show" id="L0z-Pq-QIG"/>
+                                        </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7d5-Qt-jga" style="IBUITableViewCellStyleDefault" id="b5y-qy-hIL">
                                         <rect key="frame" x="20" y="459.5" width="374" height="43.5"/>
@@ -465,19 +471,20 @@
                                 <rect key="frame" x="0.0" y="108" width="414" height="700"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gi6-Pv-9Ra">
-                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="itemSize" width="332" height="77"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="4fN-8y-6tN">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <rect key="frame" x="41" y="0.0" width="332" height="77"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="cDF-mW-ken">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="332" height="77"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </collectionViewCellContentView>
+                                        <size key="customSize" width="332" height="77"/>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
@@ -498,7 +505,39 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qw2-ax-zOV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2687" y="836"/>
+            <point key="canvasLocation" x="2686.9565217391305" y="835.71428571428567"/>
+        </scene>
+        <!--레이블-->
+        <scene sceneID="u7A-we-0ex">
+            <objects>
+                <viewController id="qgV-Aj-uCz" customClass="FilterLabelListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="cBi-7v-oE5">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="3bD-c1-FfR"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="레이블" id="iSq-9V-vHg"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vtj-yU-etk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2674" y="1489"/>
+        </scene>
+        <!--마일스톤-->
+        <scene sceneID="d93-Hb-cj0">
+            <objects>
+                <viewController id="jP9-w6-KkU" customClass="FilterMilestoneListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ZNE-Jj-Ohs">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="4O8-BU-phr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="마일스톤" id="Eyd-bS-v17"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lEM-UT-TDH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2687" y="2178"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="RRA-zr-ZA1">

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueInteractor.swift
@@ -15,7 +15,18 @@ protocol FilterIssueBusinessLogic {
     
 }
 
-class FilterIssueInteractor: FilterIssueBusinessLogic {
+class FilterIssueInteractor: FilterIssueBusinessLogic, UserListDelegate{
     
+    var author: User?
+    var assignee: User?
 
+    func didSelect(user: User, mode: UserListInteractor.UserMode) {
+        switch mode {
+        case .author:
+            self.author = user
+        case .assignee:
+            self.assignee = user
+        }
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueViewController.swift
@@ -9,9 +9,29 @@ import UIKit
 
 class FilterIssueViewController: UITableViewController {
 
+    let interactor = FilterIssueInteractor()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let segueId = segue.identifier else { return }
+        switch segueId {
+        case "showAuthorList":
+            guard let userListVC = segue.destination as? UserListViewController else { return }
+            userListVC.interactor.userMode = .author
+//            userListVC.interactor.delegate = interactor
+        case "showAssigneeList":
+            guard let userListVC = segue.destination as? UserListViewController else { return }
+            userListVC.interactor.userMode = .assignee
+
+        default:
+            break
+        }
+
+    }
+    
     
     @IBAction func didTouchBarButton(_ sender: UIBarButtonItem) {
         if sender.title == "Done" {

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterIssueViewController.swift
@@ -21,11 +21,11 @@ class FilterIssueViewController: UITableViewController {
         case "showAuthorList":
             guard let userListVC = segue.destination as? UserListViewController else { return }
             userListVC.interactor.userMode = .author
-//            userListVC.interactor.delegate = interactor
+            userListVC.interactor.delegate = interactor
         case "showAssigneeList":
             guard let userListVC = segue.destination as? UserListViewController else { return }
             userListVC.interactor.userMode = .assignee
-
+            userListVC.interactor.delegate = interactor
         default:
             break
         }

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterLabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterLabelListViewController.swift
@@ -1,0 +1,16 @@
+//
+//  FilterLabelListViewController.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/04.
+//
+
+import UIKit
+
+class FilterLabelListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterMilestoneListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterMilestoneListViewController.swift
@@ -1,0 +1,16 @@
+//
+//  FilterMilestoneListViewController.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/04.
+//
+
+import UIKit
+
+class FilterMilestoneListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
@@ -1,0 +1,8 @@
+//
+//  FilterWorker.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/03.
+//
+
+import Foundation

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
@@ -6,3 +6,43 @@
 //
 
 import Foundation
+
+class FilterWorker {
+    
+    func fetchAuthors(handler: @escaping ([User]) -> Void) {
+        let users = [User(name: "강병민", img: "temp1.jpg"),
+                     User(name: "박동현", img: "temp2.jpg"),
+                     User(name: "박인서", img: "temp3.jpg"),
+                     User(name: "신준수", img: "temp4.jpg"),
+                     User(name: "전쟁열", img: "temp5.jpg")]
+        handler(users)
+    }
+    
+    func fetchAssignes(handler: @escaping ([User]) -> Void) {
+        let users = [User(name: "강병민", img: "temp1.jpg"),
+                     User(name: "박동현", img: "temp2.jpg"),
+                     User(name: "박인서", img: "temp3.jpg"),
+                     User(name: "신준수", img: "temp4.jpg"),
+                     User(name: "전쟁열", img: "temp5.jpg")]
+        handler(users)
+    }
+    
+    func fetchMilestones(handler: @escaping ([String]) -> Void) {
+        let milestones = ["마일스톤1",
+                          "마일스톤2",
+                          "마일스톤3",
+                          "마일스톤4",
+                          "마일스톤5"]
+        handler(milestones)
+    }
+    
+    func fetchLables(handler: @escaping ([Label]) -> Void) {
+        let labels = [Label(title: "라벨1", color: "", backgroundColor: ""),
+                     Label(title: "라벨2", color: "", backgroundColor: ""),
+                     Label(title: "라벨3", color: "", backgroundColor: ""),
+                     Label(title: "라벨4", color: "", backgroundColor: ""),
+                     Label(title: "라벨5", color: "", backgroundColor: "")]
+        handler(labels)
+    }
+
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
@@ -10,20 +10,20 @@ import Foundation
 class FilterWorker {
     
     func fetchAuthors(handler: @escaping ([User]) -> Void) {
-        let users = [User(name: "강병민", img: "temp1.jpg"),
-                     User(name: "박동현", img: "temp2.jpg"),
-                     User(name: "박인서", img: "temp3.jpg"),
-                     User(name: "신준수", img: "temp4.jpg"),
-                     User(name: "전쟁열", img: "temp5.jpg")]
+        let users = [User(name: "강병민1", img: "temp1.jpg"),
+                     User(name: "박동현1", img: "temp2.jpg"),
+                     User(name: "박인서1", img: "temp3.jpg"),
+                     User(name: "신준수1", img: "temp4.jpg"),
+                     User(name: "전쟁열1", img: "temp5.jpg")]
         handler(users)
     }
     
-    func fetchAssignes(handler: @escaping ([User]) -> Void) {
-        let users = [User(name: "강병민", img: "temp1.jpg"),
-                     User(name: "박동현", img: "temp2.jpg"),
-                     User(name: "박인서", img: "temp3.jpg"),
-                     User(name: "신준수", img: "temp4.jpg"),
-                     User(name: "전쟁열", img: "temp5.jpg")]
+    func fetchAssignees(handler: @escaping ([User]) -> Void) {
+        let users = [User(name: "강병민2", img: "temp1.jpg"),
+                     User(name: "박동현2", img: "temp2.jpg"),
+                     User(name: "박인서2", img: "temp3.jpg"),
+                     User(name: "신준수2", img: "temp4.jpg"),
+                     User(name: "전쟁열2", img: "temp5.jpg")]
         handler(users)
     }
     

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
@@ -43,7 +43,7 @@ extension UserListInteractor: UserListBusinessLogic {
                 self?.users = users
             }
         case .assignee:
-            worker.fetchAuthors { [weak self] (users) in
+            worker.fetchAssignees { [weak self] (users) in
                 self?.users = users
             }
         case .none:

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
@@ -1,0 +1,59 @@
+//
+//  UserListInteractor.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/03.
+//
+
+import Foundation
+
+protocol UserListDelegate: class {
+    func didSelect(user: User)
+}
+
+protocol UserListBusinessLogic {
+    func fetchUsers()
+    func select(user: User)
+}
+
+class UserListInteractor {
+
+    enum UserSection {
+        case main, suggest
+    }
+    enum UserMode {
+        case author, assignee
+    }
+    
+    weak var delegate: UserListDelegate?
+    weak var viewController: UserListDisplayLogic?
+    
+    var userMode: UserMode?
+    var users: [User]?
+    var worker = FilterWorker()
+    
+}
+
+extension UserListInteractor: UserListBusinessLogic {
+    
+    func fetchUsers() {
+        switch userMode {
+        case .author:
+            worker.fetchAuthors { [weak self] (users) in
+                self?.users = users
+            }
+        case .assignee:
+            worker.fetchAuthors { [weak self] (users) in
+                self?.users = users
+            }
+        case .none:
+            break
+        }
+        viewController?.displayUserList(with: self.users ?? [], at: .main)
+    }
+    
+    func select(user: User) {
+        delegate?.didSelect(user: user)
+    }
+
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol UserListDelegate: class {
-    func didSelect(user: User)
+    func didSelect(user: User, mode : UserListInteractor.UserMode)
 }
 
 protocol UserListBusinessLogic {
@@ -53,7 +53,8 @@ extension UserListInteractor: UserListBusinessLogic {
     }
     
     func select(user: User) {
-        delegate?.didSelect(user: user)
+        guard let userMode = userMode else { return }
+        delegate?.didSelect(user: user, mode: userMode)
     }
 
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/UserListViewController.swift
@@ -1,0 +1,70 @@
+//
+//  UserListViewController.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/03.
+//
+
+import UIKit
+
+protocol UserListDisplayLogic: class {
+    func displayUserList(with: [User], at: UserListInteractor.UserSection)
+}
+class UserListViewController: BaseCollectionViewController<UserListInteractor.UserSection, User> {
+    
+    @IBOutlet weak var userCollectionView: UICollectionView!
+    let interactor = UserListInteractor()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        interactor.viewController = self
+        configureCollectionView()
+        interactor.fetchUsers()
+    }
+    
+    private func configureCollectionView() {
+        configureDataSource(collectionView: userCollectionView,
+                            cellProvider: cellProvider(collectionView:indexPath:user:))
+        let configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        userCollectionView.collectionViewLayout = createLayout(using: configuration)
+        userCollectionView.delegate = self
+    }
+
+    private func configureCell() -> UICollectionView.CellRegistration<UICollectionViewListCell, User> {
+        return UICollectionView.CellRegistration<UICollectionViewListCell, User> { (cell, _, user) in
+            var content = cell.defaultContentConfiguration()
+            content.text = user.name
+            content.imageProperties.cornerRadius = 3.0
+            content.image = UIImage(systemName: "square.and.pencil") //우선 아무 image나 넣었습니다
+            cell.contentConfiguration = content
+        }
+    }
+
+    private func cellProvider(collectionView: UICollectionView,
+                              indexPath: IndexPath,
+                              user: User) -> UICollectionViewListCell? {
+        let cell = collectionView.dequeueConfiguredReusableCell(using: configureCell(), for: indexPath, item: user)
+        return cell
+    }
+    
+}
+extension UserListViewController: UserListDisplayLogic {
+    
+    func displayUserList(with users: [User], at section: UserListInteractor.UserSection) {
+        var snapshot = Snapshot()
+        snapshot.appendSections([section])
+        snapshot.appendItems(users, toSection: section)
+        dataSource.apply(snapshot)
+    }
+    
+}
+
+extension UserListViewController: UICollectionViewDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let selectedAuthor = dataSource.itemIdentifier(for: indexPath) else { return }
+        interactor.select(user: selectedAuthor)
+        navigationController?.popViewController(animated: true)
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/Issue.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/Issue.swift
@@ -14,7 +14,7 @@ struct Issue: Codable {
     let milestone: String
     let labels: [Label]
     let author: String
-    let assignees: [Assignee]
+    let assignees: [User]
     var isOpen: Bool
     let createAt: String
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/User.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct User: Codable {
+struct User: Codable, Hashable {
     let name: String
     let img: String
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/User.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Assignee: Codable {
+struct User: Codable {
     let name: String
     let img: String
 }


### PR DESCRIPTION
어제 밤 이후로 필터화면의 진도를 어떻게 나갈까 고민을 하다가
우선은 작성자/담당자에 해당하는 화면만 최대한 구현했습니다
근데 생각해보니까 fetch하는 data만 다른것 빼고는 **완벽히 똑같아서** 어떻게 해서 중복을 막을까 고민을 엄청 많이했습니다.
(ps... 지금생각해보니 fetch하는 data까지 똑같을것같아요 어처피 해당 저장소의 모든 유저를 보여줄테니까....)


처음에 고민한건 중복되는 코드를 하나의 클래스에 넣고 마지막에 AuthorVC, AssigneeVC가 각각 상속받고 차이나는 부분만 따로 코딩할까? 고민을했는데.... 

하나의 UserListViewController,UserListInteractor만 만들었습니다
그려면, author를 불러와야하는지, assignee를 불러와야하는지는 **어떻게 아나???**
UserMode라는 enum을 만들어서 mode에 따라 달라지게 했습니다.

```
//UserListInteractor 일부...
    enum UserMode {
        case author, assignee
    }
    
    
    var userMode: UserMode?
    
    '
    '
    '
    '
    '
    func fetchUsers() {
        switch userMode {
        case .author:
            worker.fetchAuthors { [weak self] (users) in
                self?.users = users
            }
        case .assignee:
            worker.fetchAssignees { [weak self] (users) in
                self?.users = users
            }
        case .none:
            break
        }
        viewController?.displayUserList(with: self.users ?? [], at: .main)
    }

```
그리고 이 usermode는 prepare segue를 할때 정해줍니다!


```
//FilterIssueViewController 일부..

        switch segueId {
        case "showAuthorList":
            guard let userListVC = segue.destination as? UserListViewController else { return }
            userListVC.interactor.userMode = .author
            userListVC.interactor.delegate = interactor
        case "showAssigneeList":
            guard let userListVC = segue.destination as? UserListViewController else { return }
            userListVC.interactor.userMode = .assignee
            userListVC.interactor.delegate = interactor

```

중복되는 코드를 어떻게 처리할까 해서 생각해낸(?) 해결방법인데 어떤가용?
혹시 더 좋은 아이디어가 있으면 적극 환영입니다!
*ps. prepare seuge에서 switch도 중복되는 코드를 줄이고 싶은데... 우선은 패스했습니당.*






## cellProvider
이전에 IssueList에서는 storyboard에 cell을 꾸미고, subcalssing을 통해서
` collectionView.dequeueReusableCell(withReuseIdentifier: ##, for: ##)`
이런식으로 했는데, 
이번에는 `UICollectionView.CellRegistration`와 `collectionView.dequeueConfiguredReusableCell`를 이용했습니다

이유는 기본적으로 제공되는 contentConfiguration으로 충분히 목록을 만들수 있을 것 같기 때문입니다.
*다만 label하고 milestone은 어떻게 해야할지 조금 고민해봐야할것같아요.*

참고한 자료는 저희가 항상 봐왔던 apple공식 자료입니다
```
    //이코드가 애플 코드!
    // EmojiExplorerListViewController.swift중 일부
    func configureDataSource() {

        // list cell
        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Emoji> { (cell, indexPath, emoji) in
            var contentConfiguration = UIListContentConfiguration.valueCell()
            contentConfiguration.text = emoji.text
            contentConfiguration.secondaryText = String(describing: emoji.category)
            cell.contentConfiguration = contentConfiguration

            cell.accessories = [.disclosureIndicator()]
        }
        
        // data source
        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) {
            (collectionView, indexPath, item) -> UICollectionViewCell? in
            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: item.emoji)
        }
    }
```



# 고민거리 (사용자의 UX를 생각해보면....)

## 현재 선택된 item이 뭔지 보여주기

처음에 list를 볼때는 당연히 checkmark가 없겠지만
한번 선택하고 나서는 사용자가 **그전에 선택한 항목에** checkmark가 있었으면 좋겠다고 생각이 들었습니다
ex)
![](https://i.imgur.com/Ebl0KTM.png)


```
            if user.isSelected {
                cell.accessories = [.checkmark()]
            }
```
뭔가.... 이런식으로 해주고싶은데...

## (author/assignee)한정 
우선은 
diffable datasource의 item을 Hashable하게 만들고
```
struct User: Codable, Hashable {
    let name: String
    let img: String
}
```
로 collectionview의 item을 configure하긴했지만...
**결국에는 image url을 UIImage로 바꿔주는 작업이 필요할것같습니다**

그래서 순수히 model역할을하는 User따로, 그리고 **viewModel 역할을** 하는 UserViewModel이 필요하지않을까? 라고 생각이 들었습니다
```
struct User: Codable {
    let name: String
    let img: String
}
struct UserViewModel: Codable, Hashable {
    let name: String
    let img: UIImage
    let isSelected: Bool //위에서 언급한 isSelected을 여기서 지정해주면 좋을것같다고 생각해요!
}
```
그러면 자연스럽게 
diffable datasource의 item은 User가 아니라 UserViewModel을 갖게 될것 같아요


## section은 어디에??
section enum은 interactor에 넣었습니다
나중에 추천받은 user는 section을 따로 구분하는게 좋을것같아서 suggest라는 case도 하나 만들었어요
```
class UserListInteractor {

    enum UserSection {
        case main, suggest
    }
    
    weak var delegate: UserListDelegate?
    weak var viewController: UserListDisplayLogic?
    var authors: [User]?
    var worker = FilterWorker()
}
```

## 마무리를 하자면....

1.어제 밤에 "우선은 큰틀로 구현해보자!"라는 마음으로 쓴 코드라 보완할점이 좀 있을것 같아요

2.코드의 이해를 돕고자 commit과 PR에 신경을 좀 썼지만, 부족한 부분은 이따 같이 얘기를 나누면 좋을 것 같아요!

