### PR TITLE
[#개발환경] Prettier 적용

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,13 +1,11 @@
 module.exports = {
   env: {
-    browser: true,
     es6: true,
     node: true,
   },
   extends: ['eslint:recommended', 'prettier'],
   parserOptions: {
     ecmaVersion: 12,
-    sourceType: 'module',
   },
   rules: {
     indent: ['error', 2, { SwitchCase: 1 }],
@@ -32,6 +30,6 @@ module.exports = {
     'key-spacing': ['error', { mode: 'strict' }],
     'arrow-spacing': ['error', { before: true, after: true }],
     'eol-last': 'error',
-    quotes: ['error', 'single'],
+    quotes: ['error', 'single', { avoidEscape: true }],
   },
 };

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,17 +1,17 @@
 module.exports = {
-  'env': {
-    'browser': true,
-    'es6': true,
-    'node': true,
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
   },
-  'extends': 'eslint:recommended',
-  'parserOptions': {
-    'ecmaVersion': 12,
-    'sourceType': 'module',
+  extends: ['eslint:recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: 'module',
   },
-  'rules': {
-    indent: ['error', 2, { 'SwitchCase': 1 }],
-    'semi': ['error', 'always'],
+  rules: {
+    indent: ['error', 2, { SwitchCase: 1 }],
+    semi: ['error', 'always'],
     'no-trailing-spaces': 'error',
     curly: 'error',
     'brace-style': 'error',
@@ -24,7 +24,7 @@ module.exports = {
     'keyword-spacing': ['error', { before: true, after: true }],
     'comma-spacing': ['error', { before: false, after: true }],
     'comma-style': ['error', 'last'],
-    'comma-dangle': ['error', 'always-multiline'],
+    // 'comma-dangle': ['error', 'always-multiline'],
     'space-in-parens': ['error', 'never'],
     'block-spacing': 'error',
     'array-bracket-spacing': ['error', 'never'],

--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backend/.prettierrc.json
+++ b/backend/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/backend/.vscode/settings.json
+++ b/backend/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/backend/app.js
+++ b/backend/app.js
@@ -7,9 +7,11 @@ const router = require('./src/routes');
 
 const app = express();
 
-app.use(logger('dev', {
-  skip: () => process.env.NODE_ENV === 'test',
-}));
+app.use(
+  logger('dev', {
+    skip: () => process.env.NODE_ENV === 'test',
+  })
+);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2607,6 +2607,15 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3245,6 +3254,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -6342,6 +6357,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
     },
     "pretty-format": {
       "version": "26.6.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,9 @@
   },
   "devDependencies": {
     "eslint": "^7.12.1",
+    "eslint-config-prettier": "^6.15.0",
     "jest": "^26.6.3",
+    "prettier": "2.1.2",
     "sequelize-cli": "^6.2.0",
     "supertest": "^6.0.1",
     "umzug": "^3.0.0-beta.8"

--- a/backend/src/db/config/config.js
+++ b/backend/src/db/config/config.js
@@ -3,27 +3,27 @@ const fs = require('fs');
 const dotenv = require('dotenv').config();
 
 module.exports = {
-  'development': {
-    'username': process.env.DEV_DB_USERNAME,
-    'password': process.env.DEV_DB_PASSWORD,
-    'database': process.env.DEV_DB_NAME,
-    'host': process.env.DEV_DB_HOST,
-    'dialect': 'mysql',
+  development: {
+    username: process.env.DEV_DB_USERNAME,
+    password: process.env.DEV_DB_PASSWORD,
+    database: process.env.DEV_DB_NAME,
+    host: process.env.DEV_DB_HOST,
+    dialect: 'mysql',
   },
-  'test': {
-    'username': process.env.CI_DB_USERNAME,
-    'password': process.env.CI_DB_PASSWORD,
-    'database': process.env.CI_DB_NAME,
-    'host': process.env.CI_DB_HOST,
-    'dialect': 'mysql',
-    'logging': false,
+  test: {
+    username: process.env.CI_DB_USERNAME,
+    password: process.env.CI_DB_PASSWORD,
+    database: process.env.CI_DB_NAME,
+    host: process.env.CI_DB_HOST,
+    dialect: 'mysql',
+    logging: false,
   },
-  'production': {
-    'username': process.env.PROD_DB_USERNAME,
-    'password': process.env.PROD_DB_PASSWORD,
-    'database': process.env.PROD_DB_NAME,
-    'host': process.env.PROD_DB_HOST,
-    'dialect': 'mysql',
-    'logging': false,
+  production: {
+    username: process.env.PROD_DB_USERNAME,
+    password: process.env.PROD_DB_PASSWORD,
+    database: process.env.PROD_DB_NAME,
+    host: process.env.PROD_DB_HOST,
+    dialect: 'mysql',
+    logging: false,
   },
 };

--- a/backend/src/db/migrations/20201102160147-add-associations-oneToMany.js
+++ b/backend/src/db/migrations/20201102160147-add-associations-oneToMany.js
@@ -2,68 +2,40 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn(
-      'Issues',
-      'authorId',
-      {
-        type: Sequelize.INTEGER,
-        references: {
-          model: 'Users',
-          key: 'id',
-        },
+    await queryInterface.addColumn('Issues', 'authorId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id',
       },
-    );
-    await queryInterface.addColumn(
-      'Issues',
-      'milestoneId',
-      {
-        type: Sequelize.INTEGER,
-        references: {
-          model: 'Milestones',
-          key: 'id',
-        },
+    });
+    await queryInterface.addColumn('Issues', 'milestoneId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Milestones',
+        key: 'id',
       },
-    );
-    await queryInterface.addColumn(
-      'Comments',
-      'userId',
-      {
-        type: Sequelize.INTEGER,
-        references: {
-          model: 'Users',
-          key: 'id',
-        },
+    });
+    await queryInterface.addColumn('Comments', 'userId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id',
       },
-    );
-    await queryInterface.addColumn(
-      'Comments',
-      'issueId',
-      {
-        type: Sequelize.INTEGER,
-        references: {
-          model: 'Issues',
-          key: 'id',
-        },
+    });
+    await queryInterface.addColumn('Comments', 'issueId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Issues',
+        key: 'id',
       },
-    );
+    });
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeColumn(
-      'Issues',
-      'authorId',
-    );
-    await queryInterface.removeColumn(
-      'Issues',
-      'milestoneId',
-    );
-    await queryInterface.removeColumn(
-      'Comments',
-      'userId',
-    );
-    await queryInterface.removeColumn(
-      'Comments',
-      'issueId',
-    );
+    await queryInterface.removeColumn('Issues', 'authorId');
+    await queryInterface.removeColumn('Issues', 'milestoneId');
+    await queryInterface.removeColumn('Comments', 'userId');
+    await queryInterface.removeColumn('Comments', 'issueId');
   },
 };

--- a/backend/src/db/migrations/20201102161947-add-associations-manyToMany.js
+++ b/backend/src/db/migrations/20201102161947-add-associations-manyToMany.js
@@ -2,48 +2,42 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable(
-      'Assignees',
-      {
-        userId: {
-          type: Sequelize.INTEGER,
-          primaryKey: true,
-        },
-        issueId: {
-          type: Sequelize.INTEGER,
-          primaryKey: true,
-        },
-        createdAt: {
-          allowNull: false,
-          type: Sequelize.DATE,
-        },
-        updatedAt: {
-          allowNull: false,
-          type: Sequelize.DATE,
-        },
+    await queryInterface.createTable('Assignees', {
+      userId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
       },
-    );
-    await queryInterface.createTable(
-      'IssueLabels',
-      {
-        issueId: {
-          type: Sequelize.INTEGER,
-          primaryKey: true,
-        },
-        labelId: {
-          type: Sequelize.INTEGER,
-          primaryKey: true,
-        },
-        createdAt: {
-          allowNull: false,
-          type: Sequelize.DATE,
-        },
-        updatedAt: {
-          allowNull: false,
-          type: Sequelize.DATE,
-        },
+      issueId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
       },
-    );
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+    await queryInterface.createTable('IssueLabels', {
+      issueId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+      },
+      labelId: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/backend/src/db/models/comment.js
+++ b/backend/src/db/models/comment.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model,
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class Comment extends Model {
@@ -10,11 +8,14 @@ module.exports = (sequelize, DataTypes) => {
       Comment.belongsTo(models.Issue);
     }
   }
-  Comment.init({
-    description: DataTypes.STRING,
-  }, {
-    sequelize,
-    modelName: 'Comment',
-  });
+  Comment.init(
+    {
+      description: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'Comment',
+    }
+  );
   return Comment;
 };

--- a/backend/src/db/models/index.js
+++ b/backend/src/db/models/index.js
@@ -12,20 +12,29 @@ let sequelize;
 if (config.use_env_variable) {
   sequelize = new Sequelize(process.env[config.use_env_variable], config);
 } else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
+  sequelize = new Sequelize(
+    config.database,
+    config.username,
+    config.password,
+    config
+  );
 }
 
-fs
-  .readdirSync(__dirname)
-  .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+fs.readdirSync(__dirname)
+  .filter((file) => {
+    return (
+      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
+    );
   })
-  .forEach(file => {
-    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+  .forEach((file) => {
+    const model = require(path.join(__dirname, file))(
+      sequelize,
+      Sequelize.DataTypes
+    );
     db[model.name] = model;
   });
 
-Object.keys(db).forEach(modelName => {
+Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
   }

--- a/backend/src/db/models/issue.js
+++ b/backend/src/db/models/issue.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model,
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class Issue extends Model {
@@ -18,14 +16,17 @@ module.exports = (sequelize, DataTypes) => {
       Issue.belongsTo(models.Milestone);
     }
   }
-  Issue.init({
-    title: DataTypes.STRING,
-    isOpen: DataTypes.BOOLEAN,
-    isDeleted: DataTypes.BOOLEAN,
-    preview: DataTypes.STRING,
-  }, {
-    sequelize,
-    modelName: 'Issue',
-  });
+  Issue.init(
+    {
+      title: DataTypes.STRING,
+      isOpen: DataTypes.BOOLEAN,
+      isDeleted: DataTypes.BOOLEAN,
+      preview: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'Issue',
+    }
+  );
   return Issue;
 };

--- a/backend/src/db/models/label.js
+++ b/backend/src/db/models/label.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model,
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class Label extends Model {
@@ -11,15 +9,18 @@ module.exports = (sequelize, DataTypes) => {
       });
     }
   }
-  Label.init({
-    title: DataTypes.STRING,
-    description: DataTypes.STRING,
-    color: DataTypes.STRING,
-    backgroundColor: DataTypes.STRING,
-    isDeleted: DataTypes.BOOLEAN,
-  }, {
-    sequelize,
-    modelName: 'Label',
-  });
+  Label.init(
+    {
+      title: DataTypes.STRING,
+      description: DataTypes.STRING,
+      color: DataTypes.STRING,
+      backgroundColor: DataTypes.STRING,
+      isDeleted: DataTypes.BOOLEAN,
+    },
+    {
+      sequelize,
+      modelName: 'Label',
+    }
+  );
   return Label;
 };

--- a/backend/src/db/models/milestone.js
+++ b/backend/src/db/models/milestone.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model,
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class Milestone extends Model {
@@ -9,14 +7,17 @@ module.exports = (sequelize, DataTypes) => {
       Milestone.hasMany(models.Issue);
     }
   }
-  Milestone.init({
-    title: DataTypes.STRING,
-    description: DataTypes.STRING,
-    dueDate: DataTypes.DATE,
-    isDeleted: DataTypes.BOOLEAN,
-  }, {
-    sequelize,
-    modelName: 'Milestone',
-  });
+  Milestone.init(
+    {
+      title: DataTypes.STRING,
+      description: DataTypes.STRING,
+      dueDate: DataTypes.DATE,
+      isDeleted: DataTypes.BOOLEAN,
+    },
+    {
+      sequelize,
+      modelName: 'Milestone',
+    }
+  );
   return Milestone;
 };

--- a/backend/src/db/models/user.js
+++ b/backend/src/db/models/user.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model,
-} = require('sequelize');
+const { Model } = require('sequelize');
 
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
@@ -15,15 +13,18 @@ module.exports = (sequelize, DataTypes) => {
       });
     }
   }
-  User.init({
-    userName: DataTypes.STRING,
-    password: DataTypes.STRING,
-    profile: DataTypes.STRING,
-    authType: DataTypes.STRING,
-    isDeleted: DataTypes.BOOLEAN,
-  }, {
-    sequelize,
-    modelName: 'User',
-  });
+  User.init(
+    {
+      userName: DataTypes.STRING,
+      password: DataTypes.STRING,
+      profile: DataTypes.STRING,
+      authType: DataTypes.STRING,
+      isDeleted: DataTypes.BOOLEAN,
+    },
+    {
+      sequelize,
+      modelName: 'User',
+    }
+  );
   return User;
 };

--- a/backend/src/db/seeders/20201102174302-sample-user.js
+++ b/backend/src/db/seeders/20201102174302-sample-user.js
@@ -2,33 +2,37 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Users', [{
-      userName: 'junsushin-dev',
-      password: 'junsushin-devpw',
-      profile: 'https://avatars3.githubusercontent.com/u/32405358?s=400&u=cbda272c344b4c9e35cc1ee452f0bc4eae7e34c3&v=4',
-      authType: 'local',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      userName: 'parkdit94',
-      password: 'parkdit94pw',
-      profile: 'https://avatars1.githubusercontent.com/u/52442237?s=400&u=48c1ef65d9f5094f65f99e02dd1191656c57425f&v=4',
-      authType: 'local',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      userName: 'passwd10',
-      password: 'pwsswd10pw',
-      profile: 'https://avatars0.githubusercontent.com/u/68668924?s=400&v=4',
-      authType: 'local',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('Users', [
+      {
+        userName: 'junsushin-dev',
+        password: 'junsushin-devpw',
+        profile:
+          'https://avatars3.githubusercontent.com/u/32405358?s=400&u=cbda272c344b4c9e35cc1ee452f0bc4eae7e34c3&v=4',
+        authType: 'local',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userName: 'parkdit94',
+        password: 'parkdit94pw',
+        profile:
+          'https://avatars1.githubusercontent.com/u/52442237?s=400&u=48c1ef65d9f5094f65f99e02dd1191656c57425f&v=4',
+        authType: 'local',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userName: 'passwd10',
+        password: 'pwsswd10pw',
+        profile: 'https://avatars0.githubusercontent.com/u/68668924?s=400&v=4',
+        authType: 'local',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/backend/src/db/seeders/20201102174327-sample-label.js
+++ b/backend/src/db/seeders/20201102174327-sample-label.js
@@ -2,37 +2,38 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Labels', [{
-      title: 'enhancement',
-      description: 'New feature or request',
-      color: '#000000',
-      backgroundColor: '#a2eeef',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      title: 'bug',
-      description: 'Something isn\'t working',
-      color: '#FFFFFF',
-      backgroundColor: '#d73a4a',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      title: 'documentation',
-      description: 'Improvements or additions to documentation',
-      color: '#FFFFFF',
-      backgroundColor: '#0075ca',
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('Labels', [
+      {
+        title: 'enhancement',
+        description: 'New feature or request',
+        color: '#000000',
+        backgroundColor: '#a2eeef',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        title: 'bug',
+        description: "Something isn't working",
+        color: '#FFFFFF',
+        backgroundColor: '#d73a4a',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        title: 'documentation',
+        description: 'Improvements or additions to documentation',
+        color: '#FFFFFF',
+        backgroundColor: '#0075ca',
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {
     await queryInterface.bulkDelete('Labels', null, {});
   },
 };
-

--- a/backend/src/db/seeders/20201102174333-sample-milestone.js
+++ b/backend/src/db/seeders/20201102174333-sample-milestone.js
@@ -2,26 +2,27 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Milestones', [{
-      title: '1주차 - Web',
-      description: '1주차 Web Milestone',
-      dueDate: new Date('2020-10-30'),
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      title: '1주차 - iOS',
-      description: '1주차 iOS Milestone',
-      dueDate: new Date('2020-10-30'),
-      isDeleted: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('Milestones', [
+      {
+        title: '1주차 - Web',
+        description: '1주차 Web Milestone',
+        dueDate: new Date('2020-10-30'),
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        title: '1주차 - iOS',
+        description: '1주차 iOS Milestone',
+        dueDate: new Date('2020-10-30'),
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {
     await queryInterface.bulkDelete('Milestones', null, {});
   },
 };
-

--- a/backend/src/db/seeders/20201102174339-sample-issue.js
+++ b/backend/src/db/seeders/20201102174339-sample-issue.js
@@ -2,30 +2,32 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Issues', [{
-      title: '레이블 목록 보기 구현',
-      isOpen: true,
-      isDeleted: false,
-      preview: '레이블 전체 목록을 볼 수 있어야 한다. 2줄까지 보입니다.',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      authorId: 1,
-      milestoneId: 1,
-    },
-    {
-      title: '마일스톤 목록 보기 구현',
-      isOpen: true,
-      isDeleted: false,
-      preview: '마일스톤 전체 목록을 볼 수 있어야 한다. 길면 뒷부분이 ... 잘린다',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      authorId: 2,
-      milestoneId: 2,
-    }]);
+    await queryInterface.bulkInsert('Issues', [
+      {
+        title: '레이블 목록 보기 구현',
+        isOpen: true,
+        isDeleted: false,
+        preview: '레이블 전체 목록을 볼 수 있어야 한다. 2줄까지 보입니다.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: 1,
+        milestoneId: 1,
+      },
+      {
+        title: '마일스톤 목록 보기 구현',
+        isOpen: true,
+        isDeleted: false,
+        preview:
+          '마일스톤 전체 목록을 볼 수 있어야 한다. 길면 뒷부분이 ... 잘린다',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: 2,
+        milestoneId: 2,
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {
     await queryInterface.bulkDelete('Issues', null, {});
   },
 };
-

--- a/backend/src/db/seeders/20201102174345-sample-comment.js
+++ b/backend/src/db/seeders/20201102174345-sample-comment.js
@@ -2,20 +2,22 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Comments', [{
-      userId: 1,
-      description: '레이블 전체 목록을 볼 수 있는게 어떨까요',
-      issueId: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      userId: 2,
-      description: '긍정적인 기능이네요',
-      issueId: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('Comments', [
+      {
+        userId: 1,
+        description: '레이블 전체 목록을 볼 수 있는게 어떨까요',
+        issueId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: 2,
+        description: '긍정적인 기능이네요',
+        issueId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/backend/src/db/seeders/20201102182107-sample-assignee.js
+++ b/backend/src/db/seeders/20201102182107-sample-assignee.js
@@ -2,18 +2,20 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('Assignees', [{
-      userId: 1,
-      issueId: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      userId: 2,
-      issueId: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('Assignees', [
+      {
+        userId: 1,
+        issueId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: 2,
+        issueId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/backend/src/db/seeders/20201102182116-sample-issueLabel.js
+++ b/backend/src/db/seeders/20201102182116-sample-issueLabel.js
@@ -2,18 +2,20 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.bulkInsert('IssueLabels', [{
-      issueId: 1,
-      labelId: 1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    {
-      issueId: 1,
-      labelId: 2,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }]);
+    await queryInterface.bulkInsert('IssueLabels', [
+      {
+        issueId: 1,
+        labelId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        issueId: 1,
+        labelId: 2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   down: async (queryInterface, Sequelize) => {

--- a/backend/src/db/utils/initDatabase.js
+++ b/backend/src/db/utils/initDatabase.js
@@ -9,41 +9,45 @@ const disableLogger = (sequelize) => {
   sequelize.options.logging = false;
 };
 
-const getMigrations = (logger) => new Umzug({
-  migrations: {
-    glob: path.resolve(__dirname, '../migrations/*.js'),
-    resolve: ({ name, path, context }) => {
-      const migration = require(path);
-      return {
-        name,
-        up: () => migration.up(...context),
-        down: () => migration.down(...context),
-      };
+const getMigrations = (logger) =>
+  new Umzug({
+    migrations: {
+      glob: path.resolve(__dirname, '../migrations/*.js'),
+      resolve: ({ name, path, context }) => {
+        const migration = require(path);
+        return {
+          name,
+          up: () => migration.up(...context),
+          down: () => migration.down(...context),
+        };
+      },
     },
-  },
-  context: [sequelize.getQueryInterface(), db.Sequelize],
-  storage: new SequelizeStorage({ sequelize }),
-  logger,
-});
+    context: [sequelize.getQueryInterface(), db.Sequelize],
+    storage: new SequelizeStorage({ sequelize }),
+    logger,
+  });
 
-const getSeeders = (logger) => new Umzug({
-  migrations: {
-    glob: path.resolve(__dirname, '../seeders/*.js'),
-    resolve: ({ name, path, context }) => {
-      const migration = require(path);
-      return {
-        name,
-        up: () => migration.up(...context),
-        down: () => migration.down(...context),
-      };
+const getSeeders = (logger) =>
+  new Umzug({
+    migrations: {
+      glob: path.resolve(__dirname, '../seeders/*.js'),
+      resolve: ({ name, path, context }) => {
+        const migration = require(path);
+        return {
+          name,
+          up: () => migration.up(...context),
+          down: () => migration.down(...context),
+        };
+      },
     },
-  },
-  context: [sequelize.getQueryInterface(), db.Sequelize],
-  storage: memoryStorage(),
-  logger,
-});
+    context: [sequelize.getQueryInterface(), db.Sequelize],
+    storage: memoryStorage(),
+    logger,
+  });
 
-const initDatabase = async ({ logger, closeAfter } = { logger: console, closeAfter: true }) => {
+const initDatabase = async (
+  { logger, closeAfter } = { logger: console, closeAfter: true }
+) => {
   disableLogger(sequelize);
   const migrations = getMigrations(logger);
   const seeders = getSeeders(logger);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -11,7 +11,14 @@ router.post('/signUp', (req, res) => {
   res.json();
 });
 
-router.get('/github/callback', passport.authenticate('github', { failureRedirect: '/login', session: false }), (req, res) => res.redirect('/'));
+router.get(
+  '/github/callback',
+  passport.authenticate('github', {
+    failureRedirect: '/login',
+    session: false,
+  }),
+  (req, res) => res.redirect('/')
+);
 
 router.get('/github', passport.authenticate('github', { session: false }));
 

--- a/backend/src/routes/issues.js
+++ b/backend/src/routes/issues.js
@@ -51,5 +51,4 @@ router.delete('/', async (req, res, next) => {
   }
 });
 
-
 module.exports = router;

--- a/backend/src/routes/labels.js
+++ b/backend/src/routes/labels.js
@@ -2,7 +2,12 @@ const express = require('express');
 const router = express.Router();
 const createError = require('http-errors');
 
-const { getLabels, addLabel, updateLabel, deleteLabel } = require('../services/labelService');
+const {
+  getLabels,
+  addLabel,
+  updateLabel,
+  deleteLabel,
+} = require('../services/labelService');
 
 const SUCCESS_MESSAGE = { message: 'success' };
 

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -50,5 +50,4 @@ router.delete('/', async (req, res, next) => {
   }
 });
 
-
 module.exports = router;

--- a/backend/src/services/commentService.js
+++ b/backend/src/services/commentService.js
@@ -14,10 +14,7 @@ const addComment = async (newComment) => {
 const updateComment = async (modifiedComment) => {
   const { id, ...modifiedTarget } = modifiedComment;
 
-  return await Comment.update(
-    modifiedTarget,
-    { where: { id: id } },
-  );
+  return await Comment.update(modifiedTarget, { where: { id: id } });
 };
 
 module.exports = {

--- a/backend/src/services/issueService.js
+++ b/backend/src/services/issueService.js
@@ -31,7 +31,10 @@ const applyOptionInQuery = (query) => {
 };
 
 const getFilteredIssueIds = async (query) => {
-  const [finalOption, { milestone, author, assignee, label }] = applyOptionInQuery(query);
+  const [
+    finalOption,
+    { milestone, author, assignee, label },
+  ] = applyOptionInQuery(query);
 
   const issueIds = await Issue.findAll({
     include: [milestone, author, assignee, label],
@@ -43,7 +46,9 @@ const getFilteredIssueIds = async (query) => {
 };
 
 const getIssues = async (query) => {
-  const issueIds = [...await getFilteredIssueIds(query)].map(issueId => issueId.id);
+  const issueIds = [...(await getFilteredIssueIds(query))].map(
+    (issueId) => issueId.id
+  );
 
   const SEARCH_OPTION = {
     milestone: {
@@ -91,17 +96,13 @@ const updateIssues = async (modifiedContents) => {
 
   delete modifiedContents.id;
 
-  return await Issue.update(
-    modifiedContents,
-    { where: { id: ids, isDeleted: false } },
-  );
+  return await Issue.update(modifiedContents, {
+    where: { id: ids, isDeleted: false },
+  });
 };
 
 const deleteIssues = async (id) => {
-  return await Issue.update(
-    { isDeleted: true },
-    { where: { id: id } },
-  );
+  return await Issue.update({ isDeleted: true }, { where: { id: id } });
 };
 
 module.exports = {

--- a/backend/src/services/labelService.js
+++ b/backend/src/services/labelService.js
@@ -27,9 +27,12 @@ const updateLabel = async (modifiedContents) => {
 };
 
 const deleteLabel = async (id) => {
-  const [affectedRowCount] = await Label.update({ isDeleted: true }, {
-    where: { id, isDeleted: false },
-  });
+  const [affectedRowCount] = await Label.update(
+    { isDeleted: true },
+    {
+      where: { id, isDeleted: false },
+    }
+  );
   if (affectedRowCount === 0) {
     throw new Error('No rows deleted');
   }

--- a/backend/src/services/milestoneService.js
+++ b/backend/src/services/milestoneService.js
@@ -27,12 +27,18 @@ const getClosedIssueCountAboutMilestone = async (milestoneId) => {
 
 const addIssueInfoInMilestone = async (milestones) => {
   return await Promise.all(
-    milestones.map(async(milestone) => {
+    milestones.map(async (milestone) => {
       const allIssueCount = await getAllIssueCountAboutMilestone(milestone.id);
-      const closedIssueCount = await getClosedIssueCountAboutMilestone(milestone.id);
+      const closedIssueCount = await getClosedIssueCountAboutMilestone(
+        milestone.id
+      );
 
-      return { ...milestone, allIssueCount: allIssueCount, closedIssueCount: closedIssueCount };
-    }),
+      return {
+        ...milestone,
+        allIssueCount: allIssueCount,
+        closedIssueCount: closedIssueCount,
+      };
+    })
   );
 };
 
@@ -53,16 +59,15 @@ const addMilestone = async (newMilestone) => {
 };
 
 const updateMilestone = async (modifiedContents) => {
-  return await Milestone.update(
-    modifiedContents,
-    { where: { title: modifiedContents.title } },
-  );
+  return await Milestone.update(modifiedContents, {
+    where: { title: modifiedContents.title },
+  });
 };
 
 const deleteMilestone = async (title) => {
   return await Milestone.update(
     { isDeleted: true },
-    { where: { title: title } },
+    { where: { title: title } }
   );
 };
 

--- a/backend/src/services/passportServices.js
+++ b/backend/src/services/passportServices.js
@@ -2,18 +2,26 @@ const passport = require('passport');
 const GitHubStrategy = require('passport-github2').Strategy;
 const { User } = require('../db/models');
 
-passport.use(new GitHubStrategy({
-  clientID: process.env.CLIENT_ID_GITHUB,
-  clientSecret: process.env.CLIENT_SECRET_GITHUB,
-  callbackURL: 'http://localhost:3000/api/auth/github/callback',
-  session: false,
-},
-async (accessToken, refreshToken, profile, callback) => {
-  console.log(profile);
-  const user = await User.findOrCreate({
-    where: { userName: profile.username },
-    defaults: { password: null, profile: profile._json.avatar_url, authType: 'github', isDeleted: false },
-  });
-  return callback(null, user);
-},
-));
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: process.env.CLIENT_ID_GITHUB,
+      clientSecret: process.env.CLIENT_SECRET_GITHUB,
+      callbackURL: 'http://localhost:3000/api/auth/github/callback',
+      session: false,
+    },
+    async (accessToken, refreshToken, profile, callback) => {
+      console.log(profile);
+      const user = await User.findOrCreate({
+        where: { userName: profile.username },
+        defaults: {
+          password: null,
+          profile: profile._json.avatar_url,
+          authType: 'github',
+          isDeleted: false,
+        },
+      });
+      return callback(null, user);
+    }
+  )
+);

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -1,6 +1,5 @@
 const { User } = require('../db/models');
 
-
 const getUsers = async () => {
   const users = await User.findAll({
     attributes: {
@@ -24,9 +23,12 @@ const updateUser = async (modifiedContents) => {
 };
 
 const deleteUser = async (id) => {
-  const [affectedRowCount] = await User.update({ isDeleted: true }, {
-    where: { id, isDeleted: false },
-  });
+  const [affectedRowCount] = await User.update(
+    { isDeleted: true },
+    {
+      where: { id, isDeleted: false },
+    }
+  );
   if (affectedRowCount === 0) {
     throw new Error('No rows deleted');
   }

--- a/backend/tests/integrations/labels.test.js
+++ b/backend/tests/integrations/labels.test.js
@@ -17,27 +17,29 @@ afterAll(() => {
   db.sequelize.close();
 });
 
-const originalLabels = [{
-  id: 1,
-  title: 'enhancement',
-  description: 'New feature or request',
-  color: '#000000',
-  backgroundColor: '#a2eeef',
-},
-{
-  id: 2,
-  title: 'bug',
-  description: 'Something isn\'t working',
-  color: '#FFFFFF',
-  backgroundColor: '#d73a4a',
-},
-{
-  id: 3,
-  title: 'documentation',
-  description: 'Improvements or additions to documentation',
-  color: '#FFFFFF',
-  backgroundColor: '#0075ca',
-}];
+const originalLabels = [
+  {
+    id: 1,
+    title: 'enhancement',
+    description: 'New feature or request',
+    color: '#000000',
+    backgroundColor: '#a2eeef',
+  },
+  {
+    id: 2,
+    title: 'bug',
+    description: "Something isn't working",
+    color: '#FFFFFF',
+    backgroundColor: '#d73a4a',
+  },
+  {
+    id: 3,
+    title: 'documentation',
+    description: 'Improvements or additions to documentation',
+    color: '#FFFFFF',
+    backgroundColor: '#0075ca',
+  },
+];
 
 const newLabel = {
   title: 'BE',
@@ -63,7 +65,6 @@ const successResponse = {
 };
 
 describe('test labels API CRUD', () => {
-
   describe('when sending GET request to /api/labels', () => {
     let response, status, body;
 
@@ -82,7 +83,6 @@ describe('test labels API CRUD', () => {
   });
 
   describe('when sending POST request to /api/labels', () => {
-
     describe('on initial POST request', () => {
       let response, status, body;
 
@@ -119,7 +119,6 @@ describe('test labels API CRUD', () => {
   });
 
   describe('when sending PUT request to /api/labels', () => {
-
     describe('on initial PUT request', () => {
       let response, status, body;
 
@@ -156,7 +155,6 @@ describe('test labels API CRUD', () => {
   });
 
   describe('when sending DELETE request to /api/labels', () => {
-
     describe('on initial DELETE request', () => {
       let response, status, body;
 


### PR DESCRIPTION
## 구현의도
- Eslint에서 개행과 한 줄 당 글자 수 제한을 세팅해주지 못하는 사항 보완

## 기능 흐름도, 클래스 다이어그램(선택사항)
- VSCode에서 파일 저장할 경우 eslint -> prettier 순으로 실행
- Prettier가 code format을 모두 담당하고, eslint에서 format 관련 규칙을 override

## 사용된 기술
- prettier : 코드 포맷팅 담당
- eslint-config-prettier : eslint와 prettier 호환
- VSCode Extenstion: Pretter, Eslint 를 이용한 파일 자동저장

## 리뷰 & 논의사항 & 궁금한점
- prettier를 도입할 지 저번주에 잠깐 말했었는데, 오늘 백엔드에 적용해보니 코드를 보기가 더 쉬운 것 같아서 추가해보았습니다. 꼭 이대로 적용해야 하는 것은 아니고, 이전 eslint 단독에 비해서 코드 보기가 나아졌는지 한번 보시고 괜찮으면 이야기해서 prettier를 넣으면 좋을 것 같아요.  
- 백엔드 코드 바뀐 것 보시고 괜찮다면, 프론트엔드 코드 쪽에서도 react 관련세팅과 함께 적용해서 merge 하도록 하겠습니다. 