### PR TITLE
Alert 사용시 사용자 UX 개선

### DIFF
--- a/iOS/IssueTracker/.swiftlint.yml
+++ b/iOS/IssueTracker/.swiftlint.yml
@@ -6,3 +6,4 @@ excluded: # 린트 과정에서 무시할 파일 경로. `included`보다 우선
   - IssueTrackerUITests
 disabled_rules: 
   - trailing_whitespace
+  - identifier_name

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -38,6 +38,11 @@
 		51A9F610255274180004FB52 /* FilterMilestoneListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A9F60F255274180004FB52 /* FilterMilestoneListInteractor.swift */; };
 		51A9F62B2552A8240004FB52 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A9F62A2552A8240004FB52 /* SignInViewController.swift */; };
 		51A9F6302552A84C0004FB52 /* SignInInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A9F62F2552A84C0004FB52 /* SignInInteractor.swift */; };
+		51B6D5E32556E00B00325952 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B6D5E02556E00B00325952 /* String+Date.swift */; };
+		51B6D5E42556E00B00325952 /* UIColor+hexString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B6D5E12556E00B00325952 /* UIColor+hexString.swift */; };
+		51B6D5E52556E00B00325952 /* Date+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B6D5E22556E00B00325952 /* Date+String.swift */; };
+		51B6D5EA2556EE0000325952 /* UIButton+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B6D5E92556EE0000325952 /* UIButton+UIColor.swift */; };
+		51B6D5F225577B4D00325952 /* LabelAlertInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B6D5F125577B4D00325952 /* LabelAlertInteractor.swift */; };
 		51C95CD22553CFDB00EACB1C /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95CD12553CFDB00EACB1C /* API.swift */; };
 		51C95CD72553D14F00EACB1C /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95CD62553D14F00EACB1C /* Milestone.swift */; };
 		51C95CDF2553DE9E00EACB1C /* ReponseMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95CDE2553DE9D00EACB1C /* ReponseMessage.swift */; };
@@ -120,6 +125,11 @@
 		51A9F62A2552A8240004FB52 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		51A9F62F2552A84C0004FB52 /* SignInInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInInteractor.swift; sourceTree = "<group>"; };
 		51A9F6382552CFE70004FB52 /* IssueTracker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IssueTracker.entitlements; sourceTree = "<group>"; };
+		51B6D5E02556E00B00325952 /* String+Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
+		51B6D5E12556E00B00325952 /* UIColor+hexString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+hexString.swift"; sourceTree = "<group>"; };
+		51B6D5E22556E00B00325952 /* Date+String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+String.swift"; sourceTree = "<group>"; };
+		51B6D5E92556EE0000325952 /* UIButton+UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+UIColor.swift"; sourceTree = "<group>"; };
+		51B6D5F125577B4D00325952 /* LabelAlertInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelAlertInteractor.swift; sourceTree = "<group>"; };
 		51C95CD12553CFDB00EACB1C /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		51C95CD62553D14F00EACB1C /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
 		51C95CDE2553DE9D00EACB1C /* ReponseMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReponseMessage.swift; sourceTree = "<group>"; };
@@ -224,6 +234,7 @@
 				51326E8125492F3A00C0C273 /* SceneDelegate.swift */,
 				51445A9E254A609500875BA5 /* BaseCollectionViewController.swift */,
 				51C95CD12553CFDB00EACB1C /* API.swift */,
+				51B6D5DF2556DFF300325952 /* Extensions */,
 				51C95CDE2553DE9D00EACB1C /* ReponseMessage.swift */,
 				51326EC325493DCF00C0C273 /* Scenes */,
 				51326E8525492F3A00C0C273 /* Main.storyboard */,
@@ -342,6 +353,7 @@
 				516BB59B25542C3E0030AFDD /* CustomAlertView.xib */,
 				516BB57125540A530030AFDD /* BaseAlertViewController.swift */,
 				516BB58925541E0E0030AFDD /* LabelAlertViewController.swift */,
+				51B6D5F125577B4D00325952 /* LabelAlertInteractor.swift */,
 				516BB58E25541E180030AFDD /* MilestoneAlertViewController.swift */,
 			);
 			path = Alert;
@@ -354,6 +366,17 @@
 				51A9F62F2552A84C0004FB52 /* SignInInteractor.swift */,
 			);
 			path = SignIn;
+			sourceTree = "<group>";
+		};
+		51B6D5DF2556DFF300325952 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				51B6D5E22556E00B00325952 /* Date+String.swift */,
+				51B6D5E02556E00B00325952 /* String+Date.swift */,
+				51B6D5E12556E00B00325952 /* UIColor+hexString.swift */,
+				51B6D5E92556EE0000325952 /* UIButton+UIColor.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		826F6305255154AB0005D669 /* FilterIssue */ = {
@@ -646,7 +669,9 @@
 				51326F0E2549594F00C0C273 /* IssueCollectionViewCell.swift in Sources */,
 				51445AB4254AA13000875BA5 /* LabelBadgeLabel.swift in Sources */,
 				51326EE32549407C00C0C273 /* IssueListViewController.swift in Sources */,
+				51B6D5EA2556EE0000325952 /* UIButton+UIColor.swift in Sources */,
 				516BB57225540A530030AFDD /* BaseAlertViewController.swift in Sources */,
+				51B6D5E42556E00B00325952 /* UIColor+hexString.swift in Sources */,
 				51DE98F62551898100A2E2C8 /* FilterWorker.swift in Sources */,
 				516BB57A255418690030AFDD /* AlertDisplayable.swift in Sources */,
 				51A9F6032552715E0004FB52 /* FilterMilestoneListViewController.swift in Sources */,
@@ -654,11 +679,14 @@
 				516BB58F25541E180030AFDD /* MilestoneAlertViewController.swift in Sources */,
 				51326EEB2549408A00C0C273 /* LabelListViewController.swift in Sources */,
 				51326E8025492F3A00C0C273 /* AppDelegate.swift in Sources */,
+				51B6D5E52556E00B00325952 /* Date+String.swift in Sources */,
+				51B6D5F225577B4D00325952 /* LabelAlertInteractor.swift in Sources */,
 				82B3DC262554524E00245FCD /* MilestoneDataSource.swift in Sources */,
 				82B3DC212554520700245FCD /* MilestoneListWorker.swift in Sources */,
 				51A9F62B2552A8240004FB52 /* SignInViewController.swift in Sources */,
 				516BB59725542C270030AFDD /* CustomAlertView.swift in Sources */,
 				82CF7CB7254A8B500061121C /* User.swift in Sources */,
+				51B6D5E32556E00B00325952 /* String+Date.swift in Sources */,
 				51C95CDF2553DE9E00EACB1C /* ReponseMessage.swift in Sources */,
 				82B3DC032554197600245FCD /* LabelDataSource.swift in Sources */,
 				51445AAF254AA11B00875BA5 /* MilestoneBadgeLabel.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="niz-5h-YtM">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="OJZ-QE-Jwc">
                                     <size key="itemSize" width="376" height="96"/>
@@ -136,7 +136,7 @@
                             <constraint firstItem="niz-5h-YtM" firstAttribute="trailing" secondItem="5nP-cf-veg" secondAttribute="trailing" constant="20" id="pbX-wy-1w2"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="niz-5h-YtM" secondAttribute="trailing" id="qlm-Wv-c9n"/>
                             <constraint firstItem="niz-5h-YtM" firstAttribute="bottom" secondItem="5nP-cf-veg" secondAttribute="bottom" constant="20" id="uqD-Co-4KD"/>
-                            <constraint firstItem="niz-5h-YtM" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="xxq-v4-4eV"/>
+                            <constraint firstItem="niz-5h-YtM" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="xxq-v4-4eV"/>
                             <constraint firstItem="jvR-Wf-91Z" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="zxc-uo-PNN"/>
                         </constraints>
                     </view>
@@ -160,7 +160,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="69N-WQ-Rmd">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="srm-fR-eVI">
                                     <size key="itemSize" width="414" height="128"/>
@@ -215,7 +215,7 @@
                         <constraints>
                             <constraint firstItem="69N-WQ-Rmd" firstAttribute="leading" secondItem="de7-Mc-uOs" secondAttribute="leading" id="2bG-5p-I3J"/>
                             <constraint firstItem="de7-Mc-uOs" firstAttribute="trailing" secondItem="69N-WQ-Rmd" secondAttribute="trailing" id="CnM-x2-VQg"/>
-                            <constraint firstItem="69N-WQ-Rmd" firstAttribute="top" secondItem="de7-Mc-uOs" secondAttribute="top" id="Hyw-ls-8Eg"/>
+                            <constraint firstItem="69N-WQ-Rmd" firstAttribute="top" secondItem="QFH-en-D8N" secondAttribute="top" id="Hyw-ls-8Eg"/>
                             <constraint firstItem="de7-Mc-uOs" firstAttribute="bottom" secondItem="69N-WQ-Rmd" secondAttribute="bottom" id="eRN-cp-3qn"/>
                         </constraints>
                     </view>
@@ -243,7 +243,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="0JW-Qd-0HK">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="TCF-jP-bZx">
                                     <size key="itemSize" width="414" height="128"/>
@@ -351,10 +351,10 @@ G0Rlc2NyaXB0aW9uA
                             <constraint firstItem="0JW-Qd-0HK" firstAttribute="leading" secondItem="snq-n4-Ie3" secondAttribute="leading" id="Lc3-Il-Alh"/>
                             <constraint firstItem="snq-n4-Ie3" firstAttribute="trailing" secondItem="0JW-Qd-0HK" secondAttribute="trailing" id="RjT-sP-tyq"/>
                             <constraint firstItem="snq-n4-Ie3" firstAttribute="bottom" secondItem="0JW-Qd-0HK" secondAttribute="bottom" id="VPv-Gk-dae"/>
-                            <constraint firstItem="0JW-Qd-0HK" firstAttribute="top" secondItem="snq-n4-Ie3" secondAttribute="top" id="anJ-gN-3iY"/>
+                            <constraint firstItem="0JW-Qd-0HK" firstAttribute="top" secondItem="TFE-UH-nTQ" secondAttribute="top" id="anJ-gN-3iY"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="마일스톤" id="q3b-Cs-vFe">
+                    <navigationItem key="navigationItem" title="마일스톤" largeTitleDisplayMode="always" id="q3b-Cs-vFe">
                         <barButtonItem key="rightBarButtonItem" title="Item" style="plain" id="Hu6-Hr-kAQ">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="Kd4-8o-LLR">
                                 <rect key="frame" x="376" y="11" width="18" height="22"/>

--- a/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9XJ-8C-1o0">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -992,6 +992,7 @@ G0Rlc2NyaXB0aW9uA
                     </view>
                     <connections>
                         <outlet property="alertView" destination="FoM-yc-MK0" id="fPz-vJ-KAW"/>
+                        <outlet property="colorPickerView" destination="uAR-gg-wV2" id="71c-yc-BA8"/>
                         <outlet property="colorTextField" destination="VfK-6p-vOe" id="7A0-HG-gKZ"/>
                         <outlet property="colorView" destination="Zlr-ov-ZgN" id="8Bp-uf-y3S"/>
                     </connections>
@@ -1033,6 +1034,9 @@ G0Rlc2NyaXB0aW9uA
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dyE-2u-BxU">
                             <rect key="frame" x="240" y="19" width="18" height="22"/>
                             <state key="normal" image="arrow.clockwise" catalog="system"/>
+                            <connections>
+                                <action selector="didTouchRandomButton:" destination="36N-M6-hCC" eventType="touchUpInside" id="gTX-se-uuK"/>
+                            </connections>
                         </button>
                     </subviews>
                     <viewLayoutGuide key="safeArea" id="VKM-7i-Njl"/>

--- a/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
@@ -9,12 +9,15 @@ import UIKit
 
 class BaseCollectionViewController<T: Hashable, U: Hashable>: UIViewController {
 
+    let refreshControl = UIRefreshControl()
+    
     var dataSource: UICollectionViewDiffableDataSource<T, U>! = nil
     typealias DataSource = UICollectionViewDiffableDataSource<T, U>
     typealias Snapshot = NSDiffableDataSourceSnapshot<T, U>
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        extendedLayoutIncludesOpaqueBars = true
     }
 
     func createLayout(using configuration: UICollectionLayoutListConfiguration) -> UICollectionViewLayout {

--- a/iOS/IssueTracker/IssueTracker/Extensions/Date+String.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/Date+String.swift
@@ -1,0 +1,24 @@
+//
+//  Date+String.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/07.
+//
+
+import Foundation
+
+extension Date {
+    
+    func toServerString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return formatter.string(from: self)
+    }
+
+    func toCellString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        return formatter.string(from: self)
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Extensions/String+Date.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/String+Date.swift
@@ -1,0 +1,18 @@
+//
+//  String+Date.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/07.
+//
+
+import Foundation
+
+extension String {
+    
+    func toDate() -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return formatter.date(from: self)
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Extensions/UIButton+UIColor.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/UIButton+UIColor.swift
@@ -1,0 +1,31 @@
+//
+//  UIButton.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/08.
+//
+
+import UIKit
+
+extension UIButton {
+    // https://stackoverflow.com/questions/14523348/how-to-change-the-background-color-of-a-uibutton-while-its-highlighted
+    
+    private func image(withColor color: UIColor) -> UIImage? {
+        let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
+        UIGraphicsBeginImageContext(rect.size)
+        let context = UIGraphicsGetCurrentContext()
+
+        context?.setFillColor(color.cgColor)
+        context?.fill(rect)
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return image
+    }
+
+    func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+        self.setBackgroundImage(image(withColor: color), for: state)
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Extensions/UIColor+hexString.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/UIColor+hexString.swift
@@ -1,0 +1,55 @@
+//
+//  UIColor_.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/07.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    func toHexString() -> String {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        let rgb:Int = (Int)(red*255)<<16 | (Int)(green*255)<<8 | (Int)(blue*255)<<0
+
+        return NSString(format: "#%06x", rgb) as String
+    }
+
+    convenience init(hexString: String) {
+        let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: CGFloat(a) / 255)
+    }
+    
+}
+
+extension UIColor {
+    
+    var isDarkColor: Bool {
+        var r, g, b, a: CGFloat
+        (r, g, b, a) = (0, 0, 0, 0)
+        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+        let lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return  lum < 0.50
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/BaseAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/BaseAlertViewController.swift
@@ -15,9 +15,70 @@ class BaseAlertViewController: UIViewController {
         super.viewWillAppear(animated)
         self.view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        
+        guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?
+                .cgRectValue else { return }
+        self.view.frame.origin.y = 0 - 140
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        // move back the root view origin to zero
+        self.view.frame.origin.y = 0
+    }
+    
+    func addInputAccessoryForTextFields(textFields: [UITextField],
+                                        dismissable: Bool = true,
+                                        previousNextable: Bool = false) {
+        for (index, textField) in textFields.enumerated() {
+            let toolbar: UIToolbar = UIToolbar()
+            toolbar.sizeToFit()
+            
+            var items = [UIBarButtonItem]()
+            if previousNextable {
+                
+                let previousButton = UIBarButtonItem(image: UIImage(systemName: "arrow.up"),
+                                                     style: .plain,
+                                                     target: nil,
+                                                     action: nil)
+                
+                previousButton.width = 50
+                if textField == textFields.first {
+                    previousButton.isEnabled = false
+                } else {
+                    previousButton.target = textFields[index - 1]
+                    previousButton.action = #selector(UITextField.becomeFirstResponder)
+                }
+                
+                let nextButton = UIBarButtonItem(image: UIImage(systemName: "arrow.down"),
+                                                 style: .plain,
+                                                 target: nil,
+                                                 action: nil)
+                nextButton.width = 50
+                if textField == textFields.last {
+                    nextButton.isEnabled = false
+                } else {
+                    nextButton.target = textFields[index + 1]
+                    nextButton.action = #selector(UITextField.becomeFirstResponder)
+                }
+                items.append(contentsOf: [previousButton, nextButton])
+            }
+            
+            let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let doneButton = UIBarButtonItem(image: UIImage(systemName: "keyboard.chevron.compact.down"), style: .done, target: view, action: #selector(UIView.endEditing))
 
+            items.append(contentsOf: [spacer, doneButton])
+            
+            toolbar.setItems(items, animated: true)
+            textField.inputAccessoryView = toolbar
+        }
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/CustomAlertView.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/CustomAlertView.swift
@@ -40,6 +40,7 @@ class CustomAlertView: UIView {
         view.frame = self.bounds
         self.addSubview(view)
         contentView = view
+        saveButton.setBackgroundColor(#colorLiteral(red: 0.501960814, green: 0.501960814, blue: 0.501960814, alpha: 1), for: .disabled)
     }
     
     func loadViewFromNib() -> UIView? {

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/CustomAlertView.xib
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/CustomAlertView.xib
@@ -110,6 +110,7 @@
                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                             <integer key="value" value="8"/>
                         </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
                     </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kgS-Gi-fFt">

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
@@ -1,0 +1,101 @@
+//
+//  LabelAlertInteractor.swift
+//  IssueTracker
+//
+//  Created by 강병민 on 2020/11/08.
+//
+
+import UIKit
+
+protocol LabelAlertDelegate: class {
+    func didTouchSaveButton(label: Labelable, mode: AlertMode)
+}
+
+protocol LabelAlertBuisnessLogic {
+    func randomizeColor()
+    func save(title: String?, description: String?, backgroundColor: UIColor?)
+    func didTextFieldChange(as hexString: String)
+}
+
+class LabelAlertInteractor {
+    
+    weak var delegate : LabelAlertDelegate?
+    weak var viewController: LabelAlertDisplayLogic?
+    var mode: AlertMode?
+    var id: Int?
+    
+    func isValidate(_ string: String) -> Bool {
+        let otherChars = string.dropFirst()
+        for char in otherChars where !char.isHexDigit {
+            return false
+        }
+        return true
+    }
+    
+//    func isDarkColor(_ hexString: String) -> Bool {
+//        let color = hexString.dropFirst()
+//        var rgb = parseInt(color, 16);   // convert rrggbb to decimal
+//        var r = (rgb >> 16) & 0xff;  // extract red
+//        var g = (rgb >>  8) & 0xff;  // extract green
+//        var b = (rgb >>  0) & 0xff;  // extract blue
+//
+//        var r, g, b, a: CGFloat
+//        (r, g, b, a) = (0, 0, 0, 0)
+//        self.getRed(&r, green: &g, blue: &b, alpha: &a)
+//        let lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
+//        return  lum < 0.50
+//    }
+    
+    func generateRandomColor() -> UIColor {
+        return UIColor(red: .random(in: 0...1),
+                       green: .random(in: 0...1),
+                       blue: .random(in: 0...1),
+                       alpha: 1.0)
+    }
+    
+    func generateTextColor(from color: UIColor) -> String {
+        return color.isDarkColor ? "#ffffff" : "#000000"
+    }
+    
+}
+
+extension LabelAlertInteractor: LabelAlertBuisnessLogic {
+    
+    func randomizeColor() {
+        let randomColor = generateRandomColor()
+        viewController?.displayColorPickerView(with: randomColor)
+        viewController?.displayColorTextField(with: randomColor.toHexString())
+    }
+    
+    func save(title: String?, description: String?, backgroundColor: UIColor?) {
+        guard let backgroundColor = backgroundColor else { return }
+        guard let mode = mode else { return }
+        let textColorString = generateTextColor(from: backgroundColor)
+        let backgroundColorString = backgroundColor.toHexString()// TODO: toHexString 변경시 항상 #FFFFFF반환.... 고치기
+        let label: Labelable
+        switch mode {
+        case .add:
+            label = PostLabel(title: title, description: description, color: textColorString, backgroundColor: backgroundColorString)
+        case .edit:
+            guard let id = id else { return }
+            label = PutLabel(id: id, title: title, description: description, color: textColorString, backgroundColor: backgroundColorString)
+        }
+        delegate?.didTouchSaveButton(label: label, mode: mode)
+    }
+    
+    func didTextFieldChange(as colorString: String) {
+        if colorString.isEmpty {
+            viewController?.displayColorTextField(with: "#")
+        } else if colorString.count == 7 {
+            if isValidate(colorString) {
+                viewController?.displayColorPickerView(with: UIColor(hexString: colorString))
+                viewController?.displaySaveButton(as: true)
+            } else {
+                viewController?.displaySaveButton(as: false)
+            }
+        } else {
+            viewController?.displaySaveButton(as: false)
+        }
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
@@ -32,20 +32,6 @@ class LabelAlertInteractor {
         return true
     }
     
-//    func isDarkColor(_ hexString: String) -> Bool {
-//        let color = hexString.dropFirst()
-//        var rgb = parseInt(color, 16);   // convert rrggbb to decimal
-//        var r = (rgb >> 16) & 0xff;  // extract red
-//        var g = (rgb >>  8) & 0xff;  // extract green
-//        var b = (rgb >>  0) & 0xff;  // extract blue
-//
-//        var r, g, b, a: CGFloat
-//        (r, g, b, a) = (0, 0, 0, 0)
-//        self.getRed(&r, green: &g, blue: &b, alpha: &a)
-//        let lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
-//        return  lum < 0.50
-//    }
-    
     func generateRandomColor() -> UIColor {
         return UIColor(red: .random(in: 0...1),
                        green: .random(in: 0...1),

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertInteractor.swift
@@ -19,7 +19,7 @@ protocol LabelAlertBuisnessLogic {
 
 class LabelAlertInteractor {
     
-    weak var delegate : LabelAlertDelegate?
+    weak var delegate: LabelAlertDelegate?
     weak var viewController: LabelAlertDisplayLogic?
     var mode: AlertMode?
     var id: Int?
@@ -75,10 +75,17 @@ extension LabelAlertInteractor: LabelAlertBuisnessLogic {
         let label: Labelable
         switch mode {
         case .add:
-            label = PostLabel(title: title, description: description, color: textColorString, backgroundColor: backgroundColorString)
+            label = PostLabel(title: title,
+                              description: description,
+                              color: textColorString,
+                              backgroundColor: backgroundColorString)
         case .edit:
             guard let id = id else { return }
-            label = PutLabel(id: id, title: title, description: description, color: textColorString, backgroundColor: backgroundColorString)
+            label = PutLabel(id: id,
+                             title: title,
+                             description: description,
+                             color: textColorString,
+                             backgroundColor: backgroundColorString)
         }
         delegate?.didTouchSaveButton(label: label, mode: mode)
     }

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
@@ -6,21 +6,25 @@
 //
 
 import UIKit
-protocol LabelAlertDelegate: class {
-    func didTouchSaveButton(label: Labelable, mode: AlertMode)
+
+
+protocol LabelAlertDisplayLogic: class {
+    func displaySaveButton(as isEnabled: Bool)
+    func displayColorTextField(with hexString: String)
+    func displayColorPickerView(with color: UIColor)
 }
 class LabelAlertViewController: BaseAlertViewController {
 
-    var id: Int?
     @IBOutlet weak var alertView: CustomAlertView!
     @IBOutlet var colorView: UIView!
     @IBOutlet weak var colorTextField: UITextField!
     @IBOutlet weak var colorPickerView: UIView!
     
-    weak var delegate: LabelAlertDelegate?
+    let interactor = LabelAlertInteractor()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        interactor.viewController = self
         alertView.stackView.addArrangedSubview(colorView)
         alertView.closeButton.addTarget(self, action: #selector(didTouchCloseButton), for: .touchUpInside)
         alertView.resetButton.addTarget(self, action: #selector(didTouchResetButton), for: .touchUpInside)
@@ -29,10 +33,10 @@ class LabelAlertViewController: BaseAlertViewController {
     }
     
     func configure(_ mode: AlertMode, label: Label?) {
-        self.mode = mode
+        interactor.mode = mode
         switch mode {
         case .edit:
-            self.id = label?.id
+            interactor.id = label?.id
             alertView.titleTextField.text = label?.title
             alertView.descriptionTextField.text = label?.description
             
@@ -44,41 +48,13 @@ class LabelAlertViewController: BaseAlertViewController {
         }
     }
     
-    func isValidate(_ string: String) -> Bool {
-        let otherChars = string.dropFirst()
-        for char in otherChars where !char.isHexDigit {
-            return false
-        }
-        return true
-    }
-    
     @IBAction func didTouchRandomButton(_ sender: Any) {
-        colorPickerView.backgroundColor = generateRandomColor()
-        colorTextField.text = colorPickerView.backgroundColor?.toHexString()
-    }
-    
-    func generateRandomColor() -> UIColor {
-        return UIColor(red: .random(in: 0...1),
-                       green: .random(in: 0...1),
-                       blue: .random(in: 0...1),
-                       alpha: 1.0)
+        interactor.randomizeColor()
     }
     
     @objc func didTextFieldChange(_ textField: UITextView) {
         guard let colorString = textField.text else { return }
-        
-        if colorString.isEmpty {
-            textField.text = "#"
-        } else if colorString.count == 7 {
-            if isValidate(colorString) {
-                colorPickerView.backgroundColor = UIColor(hexString: colorString)
-                alertView.saveButton.isEnabled = true
-            } else {
-                alertView.saveButton.isEnabled = false
-            }
-        } else {
-            alertView.saveButton.isEnabled = false
-        }
+        interactor.didTextFieldChange(as: colorString)
     }
     
     @objc func didTouchCloseButton() {
@@ -92,24 +68,25 @@ class LabelAlertViewController: BaseAlertViewController {
     }
     
     @objc func didTouchSaveButton() {
-        guard let mode = mode else { return }
-        guard let color = colorTextField.text else { return }
-        let backgroundColor = generateTextColor()
-        let label: Labelable
-        switch mode {
-        case .add:
-            label = PostLabel(title: alertView.titleTextField.text, description: alertView.descriptionTextField.text, color: color, backgroundColor: backgroundColor)
-        case .edit:
-            guard let id = id else { return }
-            label = PutLabel(id: id, title: alertView.titleTextField.text, description: alertView.descriptionTextField.text, color: color, backgroundColor: backgroundColor)
-        }
-        
-        delegate?.didTouchSaveButton(label: label, mode: mode)
+        interactor.save(title: alertView.titleTextField.text,
+                        description: alertView.descriptionTextField.text,
+                        backgroundColor: colorView.backgroundColor)
     }
     
-    func generateTextColor() -> String {
-        guard let isDark = colorPickerView.backgroundColor?.isDarkColor else { return "#000000"}
-        return isDark ? "#ffffff" : "#000000"
+}
+
+extension LabelAlertViewController: LabelAlertDisplayLogic {
+    
+    func displaySaveButton(as isEnabled: Bool) {
+        alertView.saveButton.isEnabled = isEnabled
+    }
+
+    func displayColorTextField(with hexString: String) {
+        colorTextField.text = hexString
+    }
+    
+    func displayColorPickerView(with color: UIColor) {
+        colorPickerView.backgroundColor = color
     }
     
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
@@ -15,6 +15,7 @@ class LabelAlertViewController: BaseAlertViewController {
     @IBOutlet weak var alertView: CustomAlertView!
     @IBOutlet var colorView: UIView!
     @IBOutlet weak var colorTextField: UITextField!
+    @IBOutlet weak var colorPickerView: UIView!
     
     weak var delegate: LabelAlertDelegate?
     
@@ -24,17 +25,59 @@ class LabelAlertViewController: BaseAlertViewController {
         alertView.closeButton.addTarget(self, action: #selector(didTouchCloseButton), for: .touchUpInside)
         alertView.resetButton.addTarget(self, action: #selector(didTouchResetButton), for: .touchUpInside)
         alertView.saveButton.addTarget(self, action: #selector(didTouchSaveButton), for: .touchUpInside)
+        colorTextField.addTarget(self, action: #selector(didTextFieldChange(_:)), for: .editingChanged)
     }
-
+    
     func configure(_ mode: AlertMode, label: Label?) {
+        self.mode = mode
         switch mode {
         case .edit:
             self.id = label?.id
             alertView.titleTextField.text = label?.title
             alertView.descriptionTextField.text = label?.description
-            colorTextField.text = label?.color
+            
+            guard let backgroundColorString = label?.backgroundColor else { return }
+            colorTextField.text = backgroundColorString
+            colorPickerView.backgroundColor = UIColor(hexString: backgroundColorString)
         default:
             break
+        }
+    }
+    
+    func isValidate(_ string: String) -> Bool {
+        let otherChars = string.dropFirst()
+        for char in otherChars where !char.isHexDigit {
+            return false
+        }
+        return true
+    }
+    
+    @IBAction func didTouchRandomButton(_ sender: Any) {
+        colorPickerView.backgroundColor = generateRandomColor()
+        colorTextField.text = colorPickerView.backgroundColor?.toHexString()
+    }
+    
+    func generateRandomColor() -> UIColor {
+        return UIColor(red: .random(in: 0...1),
+                       green: .random(in: 0...1),
+                       blue: .random(in: 0...1),
+                       alpha: 1.0)
+    }
+    
+    @objc func didTextFieldChange(_ textField: UITextView) {
+        guard let colorString = textField.text else { return }
+        
+        if colorString.isEmpty {
+            textField.text = "#"
+        } else if colorString.count == 7 {
+            if isValidate(colorString) {
+                colorPickerView.backgroundColor = UIColor(hexString: colorString)
+                alertView.saveButton.isEnabled = true
+            } else {
+                alertView.saveButton.isEnabled = false
+            }
+        } else {
+            alertView.saveButton.isEnabled = false
         }
     }
     
@@ -50,23 +93,23 @@ class LabelAlertViewController: BaseAlertViewController {
     
     @objc func didTouchSaveButton() {
         guard let mode = mode else { return }
+        guard let color = colorTextField.text else { return }
+        let backgroundColor = generateTextColor()
         let label: Labelable
         switch mode {
         case .add:
-            let backgroundColor = ""
-            let color = calculateColor(with: backgroundColor)
             label = PostLabel(title: alertView.titleTextField.text, description: alertView.descriptionTextField.text, color: color, backgroundColor: backgroundColor)
         case .edit:
-            let backgroundColor = ""
-            let color = calculateColor(with: backgroundColor)
-            label = PutLabel(id: 1, title: alertView.titleTextField.text, description: alertView.descriptionTextField.text, color: color, backgroundColor: backgroundColor)
-        default:
-            break
+            guard let id = id else { return }
+            label = PutLabel(id: id, title: alertView.titleTextField.text, description: alertView.descriptionTextField.text, color: color, backgroundColor: backgroundColor)
         }
+        
         delegate?.didTouchSaveButton(label: label, mode: mode)
     }
     
-    func calculateColor(with backgroundColor: String) -> String {
-        return ""
+    func generateTextColor() -> String {
+        guard let isDark = colorPickerView.backgroundColor?.isDarkColor else { return "#000000"}
+        return isDark ? "#ffffff" : "#000000"
     }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
@@ -25,6 +25,7 @@ class LabelAlertViewController: BaseAlertViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         interactor.viewController = self
+        addInputAccessoryForTextFields(textFields: [alertView.titleTextField, alertView.descriptionTextField, colorTextField], previousNextable: true)
         alertView.stackView.addArrangedSubview(colorView)
         alertView.closeButton.addTarget(self, action: #selector(didTouchCloseButton), for: .touchUpInside)
         alertView.resetButton.addTarget(self, action: #selector(didTouchResetButton), for: .touchUpInside)

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/LabelAlertViewController.swift
@@ -7,12 +7,12 @@
 
 import UIKit
 
-
 protocol LabelAlertDisplayLogic: class {
     func displaySaveButton(as isEnabled: Bool)
     func displayColorTextField(with hexString: String)
     func displayColorPickerView(with color: UIColor)
 }
+
 class LabelAlertViewController: BaseAlertViewController {
 
     @IBOutlet weak var alertView: CustomAlertView!

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/MilestoneAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/MilestoneAlertViewController.swift
@@ -24,7 +24,9 @@ class MilestoneAlertViewController: BaseAlertViewController {
         super.viewDidLoad()
         datePicker.backgroundColor = .none
         datePicker.tintColor = .black
-        addInputAccessoryForTextFields(textFields: [alertView.titleTextField, alertView.descriptionTextField], previousNextable: true)
+        addInputAccessoryForTextFields(textFields: [alertView.titleTextField,
+                                                    alertView.descriptionTextField],
+                                       previousNextable: true)
         alertView.stackView.addArrangedSubview(dateView)
         alertView.closeButton.addTarget(self, action: #selector(didTouchCloseButton), for: .touchUpInside)
         alertView.resetButton.addTarget(self, action: #selector(didTouchResetButton), for: .touchUpInside)
@@ -58,21 +60,19 @@ class MilestoneAlertViewController: BaseAlertViewController {
     @objc func didTouchSaveButton() {
         guard let mode = mode else { return }
         let milestone: Milestonable
-        let title = alertView.titleTextField.text
-        let description = alertView.descriptionTextField.text
+        guard let title = alertView.titleTextField.text else { return }
+        guard let description = alertView.descriptionTextField.text else { return }
         let dateString = datePicker.date.toServerString()
 
         switch mode {
         case .add:
-            print("TODO")
-//            milestone = PostMilestone(title: <#T##String#>, description: <#T##String#>, dueDate: <#T##String#>, isDeleted: <#T##Bool#>)
+            milestone = PostMilestone(title: title, description: description, dueDate: dateString, isDeleted: false)
         case .edit:
-            print("TODO")
-//            milestone = PutMilestone(id: <#T##Int#>, title: <#T##String?#>, description: <#T##String?#>, dueDate: <#T##String?#>, isDeleted: <#T##Bool#>)
-        default:
-            break
+            guard let id = id else { return }
+            milestone = PutMilestone(id: id,
+                                     title: title, description: description, dueDate: dateString, isDeleted: false)
         }
-        milestone = PutMilestone(id: 1, title: "", description: "", dueDate: "", isDeleted: false) // build에러 방지용 (나중에 지워야함)
         delegate?.didTouchSaveButton(milestone: milestone, mode: mode)
+        dismiss(animated: true, completion: nil)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/Alert/MilestoneAlertViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/Alert/MilestoneAlertViewController.swift
@@ -24,6 +24,7 @@ class MilestoneAlertViewController: BaseAlertViewController {
         super.viewDidLoad()
         datePicker.backgroundColor = .none
         datePicker.tintColor = .black
+        addInputAccessoryForTextFields(textFields: [alertView.titleTextField, alertView.descriptionTextField], previousNextable: true)
         alertView.stackView.addArrangedSubview(dateView)
         alertView.closeButton.addTarget(self, action: #selector(didTouchCloseButton), for: .touchUpInside)
         alertView.resetButton.addTarget(self, action: #selector(didTouchResetButton), for: .touchUpInside)
@@ -31,15 +32,14 @@ class MilestoneAlertViewController: BaseAlertViewController {
     }
 
     func configure(_ mode: AlertMode, milestone: Milestone?) {
+        self.mode = mode
         switch mode {
         case .edit:
             id = milestone?.id
             alertView.titleTextField.text = milestone?.title
             alertView.descriptionTextField.text = milestone?.description
-            
-            //TODO: string에서 date로 바꿔주는것 많들어야함
-//            let date = milestone?.dueDate
-//            datePicker.setDate(date, animated: true)
+            guard let date = milestone?.dueDate.toDate() else { return }
+            datePicker.setDate(date, animated: true)
         default:
             break
         }
@@ -60,8 +60,8 @@ class MilestoneAlertViewController: BaseAlertViewController {
         let milestone: Milestonable
         let title = alertView.titleTextField.text
         let description = alertView.descriptionTextField.text
-        //        DatePicker에서 고른 date를 string으로 변환시켜줘야함
-        //        let date =
+        let dateString = datePicker.date.toServerString()
+
         switch mode {
         case .add:
             print("TODO")
@@ -76,4 +76,3 @@ class MilestoneAlertViewController: BaseAlertViewController {
         delegate?.didTouchSaveButton(milestone: milestone, mode: mode)
     }
 }
-

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterLabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterLabelListViewController.swift
@@ -38,7 +38,7 @@ class FilterLabelListViewController: BaseCollectionViewController<FilterLabelInt
             let rect = CGRect(origin: .zero, size: CGSize(width: 10, height: 10))
             content.imageProperties.cornerRadius = 20.0
             UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
-            UIColor.black.setFill()
+            UIColor(hexString: label.backgroundColor ?? "#000000").setFill()
             UIRectFill(rect)
             let image = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()

--- a/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/FilterIssue/FilterWorker.swift
@@ -39,7 +39,7 @@ class FilterWorker {
     func fetchLables(handler: @escaping ([Label]) -> Void) {
         let labels = [Label(id: 1, title: "라벨1", description: "라벨1입니다", color: "", backgroundColor: ""),
                       Label(id: 2, title: "라벨2", description: "라벨2입니다", color: "", backgroundColor: ""),
-                      Label(id: 3, title: "라벨3", description: "라벨3입니다", color: "", backgroundColor: ""),]
+                      Label(id: 3, title: "라벨3", description: "라벨3입니다", color: "", backgroundColor: "")]
         handler(labels)
     }
 

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/IssueWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/IssueWorker.swift
@@ -14,7 +14,7 @@ class IssueWorker {
                             title: "이슈 0",
                             preview: "이슈 0 프리뷰 입니다.",
                             milestone: "마일스톤 1",
-                            labels: [Label(id: 1, title: "라벨입니다", description: "이것은 라벨입니다", color: "", backgroundColor: "")],
+                            labels: [Label(id: 1, title: "라벨입니다", description: "이것은 라벨입니다", color: "#000000", backgroundColor: "#a2eeef")],
                             author: "작성자",
                             assignees: [],
                             isOpen: true,

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/Milestone.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Models/Milestone.swift
@@ -15,6 +15,17 @@ struct Milestone: Codable, Hashable {
     let title, description, dueDate: String
     let isDeleted: Bool
     let createdAt, updatedAt: String
+    
+    init (postMileStone: PostMilestone, id: Int){
+        self.id = id
+        self.title = postMileStone.title
+        self.description = postMileStone.description
+        self.dueDate = postMileStone.dueDate
+        self.isDeleted = false
+        self.createdAt = Date().toServerString()
+        self.updatedAt = Date().toServerString()
+    }
+    
 }
 
 struct PostMilestone: Codable, Milestonable {

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Views/IssueCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Views/IssueCollectionViewCell.swift
@@ -18,8 +18,9 @@ class IssueCollectionViewCell: UICollectionViewListCell {
         titleLabel.text = issue.title
         previewLabel.text = issue.preview
         milestoneBadgeLabel.configure(with: issue.milestone)
-        labelBadgeLabel.configure(with: issue.labels.first?.title ?? "", color: "", backgroundColor: "")
-//        contentConfiguration = defaultContentConfiguration()
+        if let firstLabel = issue.labels.first {
+            labelBadgeLabel.configure(with: firstLabel)
+        }
         separatorLayoutGuide.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
         accessories = [.multiselect(displayed: .whenEditing, options: .init())]
     }

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Views/LabelBadgeLabel.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/Views/LabelBadgeLabel.swift
@@ -9,8 +9,10 @@ import UIKit
 
 class LabelBadgeLabel: InsetLabel {
     
-    func configure(with text: String, color: String, backgroundColor: String) {
-        self.text = text
+    func configure(with label: Label) {
+        self.text = label.title
+        self.backgroundColor = UIColor(hexString: label.backgroundColor ?? "#000000")
+        self.textColor = UIColor(hexString: label.color ?? "#FFFFFF")
         //이 뒤는 color 설정하기
     }
     

--- a/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelCollectionViewCell.swift
@@ -14,8 +14,8 @@ class LabelCollectionViewCell: UICollectionViewListCell {
     
     
     func configure(with label: Label) {
-        titleLabel.text = label.title
-        descriptionLabel.text = label.description
+        titleLabel.configure(with: label)
+        descriptionLabel.text = label.description ?? "empty"
         accessories = [.disclosureIndicator()]
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListViewController.swift
@@ -66,7 +66,7 @@ extension LabelListViewController: UICollectionViewDelegate {
         let label = dataSource.itemIdentifier(for: indexPath)
         guard let alert = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "LabelAlertViewController") as? LabelAlertViewController else { return }
         present(alert, animated: true, completion: nil)
-//        alert.delegate = self
+//        alert.interactor.delegate = self
         alert.configure(.edit, label: label)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListWorker.swift
@@ -10,7 +10,7 @@ import Foundation
 class LabelListWorker {
     func fetchLabels(handler: @escaping (LabelDataSource) -> Void) {
         API.shared.getLabels { (result) in
-            switch result{
+            switch result {
             case .success(let labels):
                 let dataSource = LabelDataSource(with: labels)
                 handler(dataSource)

--- a/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListWorker.swift
@@ -9,8 +9,14 @@ import Foundation
 
 class LabelListWorker {
     func fetchLabels(handler: @escaping (LabelDataSource) -> Void) {
-        let labels = [Label(id: 0, title: "레이블0", description: "레이블 설명입니다.", color: "", backgroundColor: ""), Label(id: 1, title: "레이블0", description: "레이블 설명입니다.", color: "", backgroundColor: "")]
-        let dataSource = LabelDataSource(with: labels)
-        handler(dataSource)
+        API.shared.getLabels { (result) in
+            switch result{
+            case .success(let labels):
+                let dataSource = LabelDataSource(with: labels)
+                handler(dataSource)
+            case .failure:
+                break
+            }
+        }
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneCollectionViewCell.swift
@@ -14,6 +14,6 @@ class MilestoneCollectionViewCell: UICollectionViewListCell {
     func configure(with milestone: Milestone) {
         titleLabel.configure(with: milestone.title)
         descriptionLabel.text = milestone.description
-        dueDateLabel.text = milestone.dueDate
+        dueDateLabel.text = milestone.dueDate.toDate()?.toCellString()
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneDataSource.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneDataSource.swift
@@ -17,4 +17,9 @@ class MilestoneDataSource {
     init(with milestones: [Milestone]) {
         self.milestones = milestones
     }
+    
+    func add(milestone: Milestone) {
+        milestones.append(milestone)
+    }
+
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListInteractor.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListInteractor.swift
@@ -9,15 +9,50 @@ import Foundation
 
 protocol MilestoneListBusinessLogic {
     func fetchMilestoneList()
+    func addMilestone(_ :PostMilestone)
 }
 
 class MilestoneListInteractor: MilestoneListBusinessLogic {
+    
     weak var viewController: MilestoneListDisplayLogic?
+    var milestoneDataSource: MilestoneDataSource?
     let worker = MilestoneListWorker()
     
     func fetchMilestoneList() {
         worker.fetchMilestones { (datasource) in
+            self.milestoneDataSource = datasource
             self.viewController?.displayMilestoneList(with: datasource.milestones, at: .main)
         }
     }
+    
+    func addMilestone(_ postMilestone: PostMilestone) {
+        guard let dataSource = milestoneDataSource else { return }
+        let newID = dataSource.milestones.count + 1
+        let newMilestone = Milestone(postMileStone: postMilestone, id: newID)
+        dataSource.add(milestone: newMilestone)
+        viewController?.displayMilestoneList(with: dataSource.milestones, at: .main)
+    }
+    
+}
+
+extension MilestoneListInteractor: MilestoneAlertDelegate {
+    func didTouchSaveButton(milestone: Milestonable, mode: AlertMode) {
+        switch mode {
+        case .add:
+            guard let milestone = milestone as? PostMilestone else { return }
+            API.shared.postMilestone(milestone) { (result) in
+                switch result {
+                case .success:
+                    self.addMilestone(milestone)
+                case .failure:
+                    print("failure")
+                }
+            }
+
+        case .edit:
+            guard let milestone = milestone as? PutMilestone else { return }
+            //TODO: put하는것 구현하기
+        }
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
@@ -23,7 +23,9 @@ class MilestoneListViewController: BaseCollectionViewController<MilestoneDataSou
     }
 
     @IBAction func didTouchAddMilestoneButton(_ sender: Any) {
-        guard let alert = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "MilestoneAlertViewController") as? MilestoneAlertViewController else { return }
+        guard let alert = UIStoryboard(name: "Main", bundle: nil)
+                .instantiateViewController(withIdentifier: "MilestoneAlertViewController")
+                as? MilestoneAlertViewController else { return }
         present(alert, animated: true, completion: nil)
         //        alert.delegate = self
         alert.configure(.add, milestone: nil)

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
@@ -21,15 +21,15 @@ class MilestoneListViewController: BaseCollectionViewController<MilestoneDataSou
         interactor.viewController = self
         interactor.fetchMilestoneList()
     }
-
+    
     @IBAction func didTouchAddMilestoneButton(_ sender: Any) {
         guard let alert = UIStoryboard(name: "Main", bundle: nil)
                 .instantiateViewController(withIdentifier: "MilestoneAlertViewController")
                 as? MilestoneAlertViewController else { return }
         present(alert, animated: true, completion: nil)
-        //        alert.delegate = self
+        alert.delegate = self.interactor
         alert.configure(.add, milestone: nil)
-
+        
     }
     
 }
@@ -67,7 +67,7 @@ extension MilestoneListViewController: UICollectionViewDelegate {
         let milestone = dataSource.itemIdentifier(for: indexPath)
         guard let alert = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "MilestoneAlertViewController") as? MilestoneAlertViewController else { return }
         present(alert, animated: true, completion: nil)
-//        alert.delegate = self.interactor
+        alert.delegate = self.interactor
         alert.configure(.edit, milestone: milestone)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListWorker.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListWorker.swift
@@ -9,7 +9,15 @@ import Foundation
 
 class MilestoneListWorker {
     func fetchMilestones(handler: @escaping (MilestoneDataSource) -> Void) {
-        let milestones = [Milestone(id: 0, title: "마일스톤 0", description: "마일스톤 입니당", dueDate: "DATE", isDeleted: true, createdAt: "", updatedAt: "")]
-        let dataSource = MilestoneDataSource(with: milestones)
-        handler(dataSource)
-    }}
+        API.shared.getMilestones { (result) in
+            switch result{
+            case .success(let milestones):
+                let dataSource = MilestoneDataSource(with: milestones)
+                handler(dataSource)
+            case .failure:
+                break
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
먼저 label에 필요한 string <-> UI color, 그리고
Milestone에 필요한 string <-> Date 을 extension을 이용하여 구현했습니다

처음에는 Extension 없이 Viewmodel을 따로 만들어서 진행 했는데
각각의 목록 화면뿐만 아니라 필터링 목록화면에도 결국에는 필요해서 extension으로 빼놨습니당
좀 급히 만들어서 extension도 나중에 refactoring하면 좋을 것 같아요


AlertVC를 이용할때 키보드가 저장 버튼을 가리는것 말고도 어떤 부분을 개선할 수 있을까?
 라는 고민을 많이 했습니다
 
## 여러개의 textfield를 이용할때

다음과 같이 textfield가 여러개 있을떄

![](https://i.imgur.com/PCSs025.png)

첫번째 textfield인 *제목*을 다 입력하고 나서, 그 다음 text field로 넘어갈때,

굳이 화면 상단에 있는 textfield를 누르지 않고서도 키보드 바로 위에서 이동을 할수 있게 했습니다.
(덤으로 키보드를 숨기는 버튼도 넣었습니다.)

![](https://i.imgur.com/SDg23oy.png)


![](https://i.imgur.com/JT7fB7z.gif)

 
 ## validate 여부를 사용자에게 알려주기
 
 
 hex string으로 선택할수 있는 색상이 형식에 맞지 않을때는 어떻게 해야할까요?
 
 사용자에게 alert 창을 띄워 줘야할까요?

 아니면 textfield아래에 label을 이용해서 알려줘야할까요?
 
 실제 github 웹사이트에서는 어떻게 처리하는지 알아봤습니다
 
 ![](https://i.imgur.com/qRf8Ppu.png)
![](https://i.imgur.com/BKjYWxE.png)

 아예 버튼이 눌리지를 않게 disable 상태로 만들어버립니다.
 
 그래서 저는 github의 아이디어를 적용해보았습니다.
 
 
 ![](https://i.imgur.com/Rjn2zy3.gif)


마지막으로navigation controller에 있는 large title 버그를 수정했습니다
수정전
![](https://i.imgur.com/MwW79Fs.png)
수정후
![](https://i.imgur.com/z0XfAr9.png)


