### PR TITLE
Pull to refresh 구현

### DIFF
--- a/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol RefreshDisplayable {
+    func configureRefreshControl(with collectionview: UICollectionView)
+}
+
 class BaseCollectionViewController<T: Hashable, U: Hashable>: UIViewController {
 
     let refreshControl = UIRefreshControl()

--- a/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/BaseCollectionViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class BaseCollectionViewController<T: Hashable, U: Hashable>: UIViewController {
 
     let refreshControl = UIRefreshControl()
+    var didBeginRefresh: (() -> Void)?
     
     var dataSource: UICollectionViewDiffableDataSource<T, U>! = nil
     typealias DataSource = UICollectionViewDiffableDataSource<T, U>
@@ -27,6 +28,12 @@ class BaseCollectionViewController<T: Hashable, U: Hashable>: UIViewController {
     func configureDataSource(collectionView: UICollectionView,
                              cellProvider: @escaping (UICollectionView, IndexPath, U) -> UICollectionViewListCell?) {
         dataSource = DataSource(collectionView: collectionView, cellProvider: cellProvider)
+    }
+    
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        if refreshControl.isRefreshing == true {
+            didBeginRefresh?()
+        }
     }
 
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/IssueList/IssueListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol IssueListDisplayLogic: class {
+protocol IssueListDisplayLogic: class, RefreshDisplayable {
     func displayIssueList(with issues: [Issue], at section: IssueDataSource.Section)
 }
 
@@ -24,6 +24,7 @@ class IssueListViewController: BaseCollectionViewController<IssueDataSource.Sect
         interactor.viewController = self
         interactor.fetchIssues()
         updateBarButtonItems()
+        configureRefreshControl(with: issueCollectionView)
         //tabBarController?.navigationController?.viewControllers.remove(at: 0)
     }
 
@@ -40,6 +41,10 @@ class IssueListViewController: BaseCollectionViewController<IssueDataSource.Sect
             viewController?.issue = issue
         }
         
+    }
+    
+    override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        super.scrollViewDidEndDecelerating(scrollView)
     }
     
     @IBAction func didTouchToolbarButton(_ sender: UIBarButtonItem) {
@@ -208,6 +213,14 @@ extension IssueListViewController: IssueListDisplayLogic {
         snapshot.appendSections([section])
         snapshot.appendItems(issues, toSection: section)
         dataSource.apply(snapshot)
+        refreshControl.endRefreshing()
+    }
+    
+    func configureRefreshControl(with collectionview: UICollectionView) {
+        collectionview.refreshControl = refreshControl
+        didBeginRefresh = {
+            self.interactor.fetchIssues()
+        }
     }
     
 }

--- a/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/LabelList/LabelListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol LabelListDisplayLogic: class {
+protocol LabelListDisplayLogic: class, RefreshDisplayable {
     func displayLabelList(with labels: [Label], at section: LabelDataSource.Section)
 }
 
@@ -22,6 +22,11 @@ class LabelListViewController: BaseCollectionViewController<LabelDataSource.Sect
         configureCollectionView()
         interactor.viewController = self
         interactor.fetchLabelList()
+        configureRefreshControl(with: labelCollectionView)
+    }
+    
+    override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        super.scrollViewDidEndDecelerating(scrollView)
     }
 
     @IBAction func didTouchAddLabelButton(_ sender: Any) {
@@ -53,12 +58,22 @@ extension LabelListViewController {
 }
 
 extension LabelListViewController: LabelListDisplayLogic {
+    
     func displayLabelList(with labels: [Label], at section: LabelDataSource.Section) {
         var snapshot = Snapshot()
         snapshot.appendSections([section])
         snapshot.appendItems(labels, toSection: section)
         dataSource.apply(snapshot)
+        refreshControl.endRefreshing()
     }
+    
+    func configureRefreshControl(with collectionview: UICollectionView) {
+        collectionview.refreshControl = refreshControl
+        didBeginRefresh = {
+            self.interactor.fetchLabelList()
+        }
+    }
+    
 }
 
 extension LabelListViewController: UICollectionViewDelegate {

--- a/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Scenes/MilestoneList/MilestoneListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol MilestoneListDisplayLogic: class {
+protocol MilestoneListDisplayLogic: class, RefreshDisplayable {
     func displayMilestoneList(with milestones: [Milestone], at section: MilestoneDataSource.Section)
 }
 
@@ -20,6 +20,11 @@ class MilestoneListViewController: BaseCollectionViewController<MilestoneDataSou
         configureCollectionView()
         interactor.viewController = self
         interactor.fetchMilestoneList()
+        configureRefreshControl(with: milestoneCollectionView)
+    }
+
+    override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        super.scrollViewDidEndDecelerating(scrollView)
     }
     
     @IBAction func didTouchAddMilestoneButton(_ sender: Any) {
@@ -54,12 +59,22 @@ extension MilestoneListViewController {
 }
 
 extension MilestoneListViewController: MilestoneListDisplayLogic {
+    
     func displayMilestoneList(with milestones: [Milestone], at section: MilestoneDataSource.Section) {
         var snapshot = Snapshot()
         snapshot.appendSections([section])
         snapshot.appendItems(milestones, toSection: section)
         dataSource.apply(snapshot)
+        refreshControl.endRefreshing()
     }
+    
+    func configureRefreshControl(with collectionview: UICollectionView) {
+        collectionview.refreshControl = refreshControl
+        didBeginRefresh = {
+            self.interactor.fetchMilestoneList()
+        }
+    }
+    
 }
 
 extension MilestoneListViewController: UICollectionViewDelegate {


### PR DESCRIPTION
중복되는 코드가 많아서 프로토콜을 이용했습니다

```
protocol RefreshDisplayable {
    func configureRefreshControl(with collectionview: UICollectionView)
}
```

그래서 각 DisplayLogic에서 RefreshDisplayable을 채택하게되고
각 목록화면에서 configureRefreshControl 를 구현하게 했습니다


```
protocol IssueListDisplayLogic: class, RefreshDisplayable {
    func displayIssueList(with issues: [Issue], at section: IssueDataSource.Section)
}

class IssueListViewController: BaseCollectionViewController<IssueDataSource.Section, Issue> {

    override func viewDidLoad() {
        super.viewDidLoad()

        configureRefreshControl(with: issueCollectionView)
    }

extension IssueListViewController: IssueListDisplayLogic {

    func configureRefreshControl(with collectionview: UICollectionView) {
        collectionview.refreshControl = refreshControl
        didBeginRefresh = {
            self.interactor.fetchIssues()
        }
    }

}
```