### PR TITLE
[#132] Users API 반환값에서 password, authType 삭제

### DIFF
--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -2,9 +2,7 @@ const { User } = require('../db/models');
 
 const getUsers = async () => {
   const users = await User.findAll({
-    attributes: {
-      exclude: ['isDeleted', 'createdAt', 'updatedAt'],
-    },
+    attributes: ['userName', 'profile'],
     where: {
       isDeleted: false,
     },


### PR DESCRIPTION
## 구현의도

- 패스워드는 API로 노출하면 안됨, authType은 queryString에 들어가지 않아 불필요

## 기능 흐름도, 클래스 다이어그램(선택사항)

## 사용된 기술

## 리뷰요청 & 논의사항 & 궁금한점

closes #132 