### PR TITLE
[#170] 단일 issue GET API 구현

### DIFF
--- a/backend/src/routes/issues.js
+++ b/backend/src/routes/issues.js
@@ -7,9 +7,19 @@ const {
   addIssue,
   updateIssues,
   deleteIssues,
+  getIssue,
 } = require('../services/issueService');
 
 const SUCCESS_MESSAGE = { message: 'success' };
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const issue = await getIssue(req.params.id);
+    res.status(200).send(issue);
+  } catch (error) {
+    next(createError(500));
+  }
+});
 
 router.get('/', async (req, res, next) => {
   try {

--- a/backend/src/services/issueService.js
+++ b/backend/src/services/issueService.js
@@ -1,4 +1,35 @@
-const { Issue, User, Label, Milestone } = require('../db/models');
+const { Issue, User, Label, Milestone, Comment } = require('../db/models');
+
+const SEARCH_OPTION = {
+  milestone: {
+    model: Milestone,
+    attributes: ['title'],
+  },
+  author: {
+    model: User,
+    as: 'author',
+    attributes: ['userName'],
+  },
+  assignee: {
+    model: User,
+    as: 'Assignee',
+    attributes: ['userName', 'profile'],
+    through: { attributes: [] },
+  },
+  label: {
+    model: Label,
+    attributes: ['title', 'color', 'backgroundColor'],
+    through: { attributes: [] },
+  },
+  comment: {
+    model: Comment,
+    attributes: ['id', 'description', 'createdAt'],
+    include: {
+      model: User,
+      attributes: ['userName', 'profile'],
+    },
+  },
+};
 
 const applyOptionInQuery = (query) => {
   const finalOption = { isDeleted: false };
@@ -50,29 +81,6 @@ const getIssues = async (query) => {
     (issueId) => issueId.id
   );
 
-  const SEARCH_OPTION = {
-    milestone: {
-      model: Milestone,
-      attributes: ['title'],
-    },
-    author: {
-      model: User,
-      as: 'author',
-      attributes: ['userName'],
-    },
-    assignee: {
-      model: User,
-      as: 'Assignee',
-      attributes: ['userName', 'profile'],
-      through: { attributes: [] },
-    },
-    label: {
-      model: Label,
-      attributes: ['title', 'color', 'backgroundColor'],
-      through: { attributes: [] },
-    },
-  };
-
   const issues = await Issue.findAll({
     include: [
       SEARCH_OPTION.milestone,
@@ -105,9 +113,23 @@ const deleteIssues = async (id) => {
   return await Issue.update({ isDeleted: true }, { where: { id: id } });
 };
 
+const getIssue = async (id) => {
+  return await Issue.findOne({
+    include: [
+      SEARCH_OPTION.milestone,
+      SEARCH_OPTION.author,
+      SEARCH_OPTION.assignee,
+      SEARCH_OPTION.label,
+      SEARCH_OPTION.comment,
+    ],
+    where: { id, isDeleted: false },
+    attributes: ['id', 'title', 'isOpen', 'preview', 'createdAt'] });
+};
+
 module.exports = {
   getIssues,
   addIssue,
   updateIssues,
   deleteIssues,
+  getIssue,
 };


### PR DESCRIPTION
closes #170 

## 구현의도
- 이슈상세 페이지에서 사용하기 위한 단일 issue GET API 구현

## 기능 흐름도, 클래스 다이어그램(선택사항)
- api/issues/{id} 로 호출 가능

## 사용된 기술

## 리뷰요청 & 논의사항 & 궁금한점
