### PR TITLE
[#202] fix: 드롭다운 modal이 상위 컴포넌트에 붙어다니도록 변경

### DIFF
--- a/frontend/src/components/FilterModal.jsx
+++ b/frontend/src/components/FilterModal.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { IssuesContext } from '../pages/IssueListPage';
 
 const Modal = styled.div`
-  position: fixed;
+  position: absolute;
   background-color: #fff;
   width: 300px;
   border: 1px solid #e1e4e8;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -6,14 +6,20 @@ import styled from 'styled-components';
 const HeaderDiv = styled.header`
   padding: 24px 0;
   text-align: center;
+  font-size: 24px;
+  font-weight: 600;
   background-color: #000000;
   color: #FFFFFF;
 `;
 
+const linkStyle = {
+  textDecoration: 'none',
+};
+
 export default function Header() {
 
   return (
-    <Link to ='/'>
+    <Link to ='/' style={linkStyle}>
       <HeaderDiv>
         ISSUES
       </HeaderDiv>

--- a/frontend/src/components/SelectSidebar/SidebarModal.jsx
+++ b/frontend/src/components/SelectSidebar/SidebarModal.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { IssueContext } from './SelectSidebar';
 
 const Modal = styled.div`
-  position: fixed;
+  position: absolute;
   background-color: #fff;
   width: 300px;
   border: 1px solid #e1e4e8;


### PR DESCRIPTION
## 구현의도

- position을 fixed에서 absolute로 변경하여 뷰포트가 아닌 상위 컴포넌트에 상대적으로
위치가 계산되도록 변경함

## 기능 흐름도, 클래스 다이어그램(선택사항)

## 사용된 기술

## 리뷰요청 & 논의사항 & 궁금한점