### PR TITLE
[#HotFix] 이슈 상세화면 코멘트 영역 에러 수정

### DIFF
--- a/frontend/src/components/CommentInput.jsx
+++ b/frontend/src/components/CommentInput.jsx
@@ -26,10 +26,11 @@ const InputBox = styled.div`
 `;
 
 const InputComment = styled.textarea`
+  width: 100%;
+  box-sizing: border-box;
   height: 200px;
   padding: 8px;
   font-size: 16px;
-  margin:10px;
   border: 1px solid #dfe2e5;
 `;
 
@@ -75,6 +76,10 @@ const WritePreviewButton = styled.button`
   color: white;
   padding: 5px;
   border-radius: 5px;
+`;
+
+const CommentContentContainer = styled.div`
+  margin: 10px;
 `;
 
 const Tabs = styled.div`
@@ -127,7 +132,9 @@ export default function CommentInput({ id }) {
               </WritePreviewButton>
             ))}
           </Tabs>
-          <div>{tabs.filter(tab => tab.title === currentTab)[0].content}</div>
+          <CommentContentContainer>
+            {tabs.filter(tab => tab.title === currentTab)[0].content}
+          </CommentContentContainer>
         </HeaderBar>
         <Buttons>
           <CommentButton onClick={() => postComment()}>

--- a/frontend/src/components/TranslateMarkdown.jsx
+++ b/frontend/src/components/TranslateMarkdown.jsx
@@ -11,7 +11,9 @@ const ShowComment = styled.div`
   background-color:white;
   min-height: 200px;
   max-height: 500px;
+  border: 1px solid #dfe2e5;
   padding: 8px;
+  box-sizing: border-box;
   font-size: 16px;
 `;
 


### PR DESCRIPTION
## 구현의도
- 코멘트 입력창과 preview를 wrapping 하는 컴포넌트의 padding 추가
- 안의 내용물을 margin을 삭제하고 border-box로 sizing 변경
